### PR TITLE
Add support for pkg-config

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -12,6 +12,9 @@ EXTRA_DIST = \
 	win32 \
 	Makefile.test
 
+pkgconfigdir = $(libdir)/pkgconfig
+pkgconfig_DATA = necpp.pc
+
 dist-hook:
 	rm -rf `find $(distdir)testharness/data -name *.out*`
 	rm -rf `find $(distdir)testharness/data -name *.diff*`

--- a/configure.ac
+++ b/configure.ac
@@ -87,8 +87,13 @@ LIBEIGEN=
 		[])
 	])
 
-
-
-
 AC_CHECK_LIB([m],[pow])
-AC_OUTPUT(Makefile src/Makefile)
+
+EXPLICIT_LIBS=""
+PRIVATE_LIBS=" $LDFLAGS -lstdc++ -llapack -lblas -lpthread -lm"
+
+AC_SUBST(EXPLICIT_LIBS)
+AC_SUBST(PRIVATE_LIBS)
+
+AC_OUTPUT(Makefile src/Makefile necpp.pc)
+

--- a/example/Makefile.pkg-config
+++ b/example/Makefile.pkg-config
@@ -1,0 +1,12 @@
+FLAGS  = `pkg-config --cflags necpp`
+LIBS = `pkg-config --libs necpp`
+SLIBS = `pkg-config --static --libs necpp`
+
+all: test_nec test_static
+
+test_nec: test_nec.c
+	gcc -Wall $(FLAGS) test_nec.c -o test_nec $(LIBS)
+
+test_static: test_nec.c
+	g++ -Wall --static $(FLAGS) test_nec.c -o test_static $(SLIBS)
+

--- a/example/test_nec.c
+++ b/example/test_nec.c
@@ -18,7 +18,7 @@ void seven_wire_antenna() {
   NEC_ERROR_HANDLE(nec_wire(nec, 2, 7, -0.0166, 0.0045, 0.0714, -0.0318, -0.0166, 0.017, 0.001, 1.0, 1.0));
   NEC_ERROR_HANDLE(nec_wire(nec, 3, 7, -0.0318, -0.0166, 0.017, -0.0318, -0.0287, 0.0775, 0.001, 1.0, 1.0));
   NEC_ERROR_HANDLE(nec_wire(nec, 4, 11, -0.0318, -0.0287, 0.0775, -0.0318, 0.0439, 0.014, 0.001, 1.0, 1.0));
-  NEC_ERROR_HANDLE(nec_wire(nec, 5, 7, -0.0318, 0.0439, 0.014, -0.0318, 0.0045, 0.0624, 0.001, 1.0, 1.0));
+/*  NEC_ERROR_HANDLE(nec_wire(nec, 5, 7, -0.0318, 0.0439, 0.014, -0.0318, 0.0045, 0.0624, 0.001, 1.0, 1.0));*/
   NEC_ERROR_HANDLE(nec_wire(nec, 6, 5, -0.0318, 0.0045, 0.0624, -0.0106, 0.0378, 0.0866, 0.001, 1.0, 1.0));
   NEC_ERROR_HANDLE(nec_wire(nec, 7, 7, -0.0106, 0.0378, 0.0866, -0.0106, 0.0257, 0.023, 0.001, 1.0, 1.0));
   NEC_ERROR_HANDLE(nec_geometry_complete(nec, 1, 0));
@@ -61,7 +61,8 @@ void simple_example() {
   nec_delete(nec);
 }
 
-int main(int argc, char **argv) {
+int main() {
   simple_example();
   seven_wire_antenna();
+  return 0;
 }

--- a/necpp.pc.in
+++ b/necpp.pc.in
@@ -1,0 +1,13 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: @PACKAGE_NAME@
+Description: @PACKAGE_NAME@: An NEC-2 compatible Numerical Electromagnetic Code
+Version: @PACKAGE_VERSION@
+URL: http://github.com/tmolteno/necpp
+Libs: -L${libdir} -l@PACKAGE@ @EXPLICIT_LIBS@
+Libs.private:@PRIVATE_LIBS@
+Cflags: -I${includedir} @CXXFLAGS@
+


### PR DESCRIPTION
I have modified Makefile.am and configure.ac in order to support pkg-config.
nec_test (C API) can be compiled statically and dynamically with Makefile_pkg.

I try to extend to the C++ API, however i am a little bit confused with the all header files (copy all the header files needed by the C++ API in /usr/local/lib seems to be a dirty solution).

Regards
