### PR TITLE
Remove self from handle_nec

### DIFF
--- a/example/test.py
+++ b/example/test.py
@@ -6,7 +6,7 @@ import necpp
 # This is built in the 'python' directory of the source code distribution
 #
 
-def handle_nec(self, result):
+def handle_nec(result):
   if (result != 0):
     print nec_error_message()
 


### PR DESCRIPTION
An error is raised if the definition of handle_nec is not changed.