### PR TITLE
Forgotten file would cause link errors at compilation with VS2013.

### DIFF
--- a/win32/nec2++/nec2++.vcxproj
+++ b/win32/nec2++/nec2++.vcxproj
@@ -184,6 +184,7 @@
     <ClCompile Include="..\..\src\nec_ground.cpp" />
     <ClCompile Include="..\..\src\nec_output.cpp" />
     <ClCompile Include="..\..\src\nec_radiation_pattern.cpp" />
+	<ClCompile Include="..\..\src\nec_results.cpp" />
     <ClCompile Include="..\..\src\nec_structure_currents.cpp" />
     <ClCompile Include="..\..\src\XGetopt.cpp" />
   </ItemGroup>


### PR DESCRIPTION
This pull request solves a linker error, to reproduce it just open Visual Studio 2013, load the solution file, build the project.