### PR TITLE
Fix nec2++.vcxproj VS2013 build errors

### DIFF
--- a/win32/nec2++/nec2++.vcxproj
+++ b/win32/nec2++/nec2++.vcxproj
@@ -184,6 +184,7 @@
     <ClCompile Include="..\..\src\nec_ground.cpp" />
     <ClCompile Include="..\..\src\nec_output.cpp" />
     <ClCompile Include="..\..\src\nec_radiation_pattern.cpp" />
+    <ClCompile Include="..\..\src\nec_results.cpp" />
     <ClCompile Include="..\..\src\nec_structure_currents.cpp" />
     <ClCompile Include="..\..\src\XGetopt.cpp" />
   </ItemGroup>


### PR DESCRIPTION
The file nec_results.cpp hadn't been included to the VS2013 project file, which caused build errors.
