### PR TITLE
Change occurrences of '=-' to ' = -' in *.c and *.cpp

### DIFF
--- a/Python/PyNEC/wrap/src/c_evlcom.cpp
+++ b/Python/PyNEC/wrap/src/c_evlcom.cpp
@@ -404,11 +404,11 @@ void c_evlcom::saoa( nec_float t, complex_array& ans)
 		com=xl-m_ck1;
 		cgam1=sqrt(xl+m_ck1)*sqrt(com);
 		if (real(com) < 0. && imag(com) >= 0.)
-			cgam1=-cgam1;
+			cgam1 = -cgam1;
 		com=xl-m_ck2;
 		cgam2=sqrt(xl+m_ck2)*sqrt(com);
 		if (real(com) < 0. && imag(com) >= 0.)
-			cgam2=-cgam2;
+			cgam2 = -cgam2;
 	}
 	
 	if (norm(xl) >= m_tsmag)
@@ -429,7 +429,7 @@ void c_evlcom::saoa( nec_float t, complex_array& ans)
 			}
 			else
 			{
-				nec_float sign=-1.0;
+				nec_float sign = -1.0;
 				dgam=1.0/(xl*xl);
 				dgam=sign*((m_ct3*dgam+m_ct2)*dgam+m_ct1)/xl;
 			} /* if (xlr >= m_ck2) */
@@ -472,17 +472,17 @@ void c_evlcom::saoa( nec_float t, complex_array& ans)
 	if (m_rho != 0.)
 	{
 		b0p=b0p/m_rho;
-		ans[0]=-com*xl*(b0p+b0*xl);
+		ans[0] = -com*xl*(b0p+b0*xl);
 		ans[3]=com*xl*b0p;
 	}
 	else
 	{
-		ans[0]=-com*xl*xl*.5;
+		ans[0] = -com*xl*xl*.5;
 		ans[3]=ans[0];
 	}
 	
 	ans[1]=com*cgam2*cgam2*b0;
-	ans[2]=-ans[3]*cgam2*m_rho;
+	ans[2] = -ans[3]*cgam2*m_rho;
 	ans[4]=com*b0;
 }
 
@@ -531,7 +531,7 @@ void c_evlcom::evlua( nec_complex *erv, nec_complex *ezv,
 		*erv=conj(m_ck1sq*ans[2]);
 		*ezv=conj(m_ck1sq*(ans[1]+m_ck2sq*ans[4]));
 		*erh=conj(m_ck2sq*(ans[0]+ans[5]));
-		*eph=-conj(m_ck2sq*(ans[3]+ans[5]));
+		*eph = -conj(m_ck2sq*(ans[3]+ans[5]));
 		
 		return;	
 	} /* if (m_zph >= 2.*m_rho) */
@@ -549,7 +549,7 @@ void c_evlcom::evlua( nec_complex *erv, nec_complex *ezv,
 	rom1(6,ans,2);
 	
 	for (int i = 0; i < 6; i++ )
-		sum[i]=-(sum[i]+ans[i]);
+		sum[i] = -(sum[i]+ans[i]);
 	
 	/* path from imaginary axis to -infinity */
 	if (m_zph > .001*m_rho)
@@ -559,7 +559,7 @@ void c_evlcom::evlua( nec_complex *erv, nec_complex *ezv,
 	
 	del=PTP/del;
 	delta=nec_complex(-1.0,slope)*del/sqrt(1.+slope*slope);
-	delta2=-conj(delta);
+	delta2 = -conj(delta);
 	gshank(cp1,delta,ans,6,sum,0,bk,bk);
 	rmis=m_rho*(real(m_ck1)-m_ck2);
 	
@@ -569,7 +569,7 @@ void c_evlcom::evlua( nec_complex *erv, nec_complex *ezv,
 		if (m_zph >= 1.e-10)
 		{
 			bk=nec_complex(-m_zph,m_rho)*(m_ck1-cp3);
-			rmis=-real(bk)/fabs(imag(bk));
+			rmis = -real(bk)/fabs(imag(bk));
 			if (rmis > 4.*m_rho/m_zph)
 				jump = true;
 		}
@@ -600,7 +600,7 @@ void c_evlcom::evlua( nec_complex *erv, nec_complex *ezv,
 	{
 		/* integrate below branch points, then to + infinity */
 		for (int i = 0; i < 6; i++ )
-			sum[i]=-ans[i];
+			sum[i] = -ans[i];
 		
 		rmis=real(m_ck1)*1.01;
 		if ( (m_ck2+1.) > rmis )
@@ -618,7 +618,7 @@ void c_evlcom::evlua( nec_complex *erv, nec_complex *ezv,
 	*erv=conj(m_ck1sq*ans[2]);
 	*ezv=conj(m_ck1sq*(ans[1]+m_ck2sq*ans[4]));
 	*erh=conj(m_ck2sq*(ans[0]+ans[5]));
-	*eph=-conj(m_ck2sq*(ans[3]+ans[5]));
+	*eph = -conj(m_ck2sq*(ans[3]+ans[5]));
 }
 
 /*-----------------------------------------------------------------------*/
@@ -675,7 +675,7 @@ void bessel( nec_complex z, nec_complex *j0, nec_complex *j0p )
   if (zms <= 1.e-12)
   {
     *j0=cplx_10;
-    *j0p=-0.5*z;
+    *j0p = -0.5*z;
     return;
   }
   
@@ -750,11 +750,11 @@ void hankel( nec_complex z, nec_complex *h0, nec_complex *h0p )
 	/* initialization of constants */
 	if ( ! hankel_init )
 	{
-		nec_float psi=-GAMMA;
+		nec_float psi = -GAMMA;
 		for (int k = 1; k <= 25; k++ )
 		{
 			int i = k-1;
-			a1[i]=-.25/(k*k);
+			a1[i] = -.25/(k*k);
 			a2[i]=1.0/(k+1.0);
 			psi += 1.0/k;
 			a3[i]=psi+psi;

--- a/Python/PyNEC/wrap/src/c_geometry.cpp
+++ b/Python/PyNEC/wrap/src/c_geometry.cpp
@@ -240,7 +240,7 @@ void c_geometry::parse_geometry(nec_context* in_context, FILE* input_fp )
 				"\n  STRUCTURE ROTATED ABOUT Z-AXIS %d TIMES"
 				" - LABELS INCREMENTED BY %d\n", card_int_2, card_int_1 );
 		
-			int ix=-1;
+			int ix = -1;
 			int iy = 0;
 			int iz = 0;
 			reflect( ix, iy, iz, card_int_1, card_int_2);
@@ -574,7 +574,7 @@ void c_geometry::geometry_complete(nec_context* in_context, int card_int_1, int 
 			if ( xw2 > 1.)
 				xw2=1.;
 			if ( xw2 < -1.)
-				xw2=-1.;
+				xw2 = -1.;
 	
 			salp[i]= xw2;
 			xw2= rad_to_degrees(asin( xw2));
@@ -920,7 +920,7 @@ void c_geometry::move( nec_float rox, nec_float roy, nec_float roz, nec_float xs
   yx= sph* cth;
   yy= sph* sth* sps+ cph* cps;
   yz= sph* sth* cps- cph* sps;
-  zx=- sth;
+  zx = - sth;
   zy= cth* sps;
   zz= cth* cps;
 
@@ -1106,10 +1106,10 @@ void c_geometry::reflect( int ix, int iy, int iz, int itx, int nop )
 	
 		x[nx]= x[i];
 		y[nx]= y[i];
-		z[nx]=- e1;
+		z[nx] = - e1;
 		x2[nx]= x2[i];
 		y2[nx]= y2[i];
-		z2[nx]=- e2;
+		z2[nx] = - e2;
 		itagi= segment_tags[i];
 	
 		if ( itagi == 0)
@@ -1155,14 +1155,14 @@ void c_geometry::reflect( int ix, int iy, int iz, int itx, int nop )
 	
 			px[nx]= px[i];
 			py[nx]= py[i];
-			pz[nx]=- pz[i];
+			pz[nx] = - pz[i];
 			t1x[nx]= t1x[i];
 			t1y[nx]= t1y[i];
-			t1z[nx]=- t1z[i];
+			t1z[nx] = - t1z[i];
 			t2x[nx]= t2x[i];
 			t2y[nx]= t2y[i];
-			t2z[nx]=- t2z[i];
-			psalp[nx]=- psalp[i];
+			t2z[nx] = - t2z[i];
+			psalp[nx] = - psalp[i];
 			pbi[nx]= pbi[i];
 		}
 	
@@ -1206,10 +1206,10 @@ void c_geometry::reflect( int ix, int iy, int iz, int itx, int nop )
 			}
 		
 			x[nx]= x[i];
-			y[nx]=- e1;
+			y[nx] = - e1;
 			z[nx]= z[i];
 			x2[nx]= x2[i];
-			y2[nx]=- e2;
+			y2[nx] = - e2;
 			z2[nx]= z2[i];
 			itagi= segment_tags[i];
 		
@@ -1255,15 +1255,15 @@ void c_geometry::reflect( int ix, int iy, int iz, int itx, int nop )
 				}
 			
 				px[nx]= px[i];
-				py[nx]=- py[i];
+				py[nx] = - py[i];
 				pz[nx]= pz[i];
 				t1x[nx]= t1x[i];
-				t1y[nx]=- t1y[i];
+				t1y[nx] = - t1y[i];
 				t1z[nx]= t1z[i];
 				t2x[nx]= t2x[i];
-				t2y[nx]=- t2y[i];
+				t2y[nx] = - t2y[i];
 				t2z[nx]= t2z[i];
-				psalp[nx]=- psalp[i];
+				psalp[nx] = - psalp[i];
 				pbi[nx]= pbi[i];
 			
 			} /* for( i = m2; i <= m; i++ ) */
@@ -1307,10 +1307,10 @@ void c_geometry::reflect( int ix, int iy, int iz, int itx, int nop )
 				throw nex;
 			}
 		
-			x[nx]=- e1;
+			x[nx] = - e1;
 			y[nx]= y[i];
 			z[nx]= z[i];
-			x2[nx]=- e2;
+			x2[nx] = - e2;
 			y2[nx]= y2[i];
 			z2[nx]= z2[i];
 			itagi= segment_tags[i];
@@ -1355,16 +1355,16 @@ void c_geometry::reflect( int ix, int iy, int iz, int itx, int nop )
 				throw nex;
 			}
 		
-			px[nx]=- px[i];
+			px[nx] = - px[i];
 			py[nx]= py[i];
 			pz[nx]= pz[i];
-			t1x[nx]=- t1x[i];
+			t1x[nx] = - t1x[i];
 			t1y[nx]= t1y[i];
 			t1z[nx]= t1z[i];
-			t2x[nx]=- t2x[i];
+			t2x[nx] = - t2x[i];
 			t2y[nx]= t2y[i];
 			t2z[nx]= t2z[i];
-			psalp[nx]=- psalp[i];
+			psalp[nx] = - psalp[i];
 			pbi[nx]= pbi[i];
 		}
 	
@@ -1375,7 +1375,7 @@ void c_geometry::reflect( int ix, int iy, int iz, int itx, int nop )
 	
 	/* reproduce structure with rotation to form cylindrical structure */
 	fnop= (nec_float)nop;
-	m_ipsym=-1;
+	m_ipsym = -1;
 	sam=two_pi() / fnop;
 	cs= cos( sam);
 	ss= sin( sam);
@@ -1814,7 +1814,7 @@ void c_geometry::connect_segments( int ignd )
         for (int i = 0; i < ic; i++ ) {
           ix= jco[i];
           if ( ix <= 0) {
-            ix=- ix;
+            ix = - ix;
             int ixx = ix-1; // TODO if ix == 0 we have a problem
             x[ixx]= xa;
             y[ixx]= ya;
@@ -2148,7 +2148,7 @@ void c_geometry::patch( int nx, int ny,
 	
 		if ( xa >= 1.0e-6)
 		{
-			t1x[mi]=- ynv/ xa;
+			t1x[mi] = - ynv/ xa;
 			t1y[mi]= xnv/ xa;
 			t1z[mi]=0.;
 		}
@@ -2603,11 +2603,11 @@ void c_geometry::tbf( int i, int icap )
 		if ( jcox != 0 )
 		{
 			if ( jcox < 0 )
-				jcox=- jcox;
+				jcox = - jcox;
 			else
 			{
 				_sig = -_sig;
-				jend=- jend;
+				jend = - jend;
 			}
 		
 			jcoxx = jcox-1;
@@ -2631,7 +2631,7 @@ void c_geometry::tbf( int i, int icap )
 			pp= pp- omc/ sd* aj;
 			ax[jsnox]= aj/ sd* _sig;
 			bx[jsnox]= aj/(2.* cdh);
-			cx[jsnox]=- aj/(2.* sdh)* _sig;
+			cx[jsnox] = - aj/(2.* sdh)* _sig;
 		
 			if ( jcox != i)
 			{
@@ -2653,13 +2653,13 @@ void c_geometry::tbf( int i, int icap )
 				}
 			} /* if ( jcox != i) */
 			else
-			bx[jsnox] =- bx[jsnox];
+			bx[jsnox] = - bx[jsnox];
 		
 			if ( iend == 1)
 				break;
 		} /* if ( jcox != 0 ) */
 	
-		pm=- pp;
+		pm = - pp;
 		pp=0.;
 		njun1= jsno;
 	
@@ -2669,7 +2669,7 @@ void c_geometry::tbf( int i, int icap )
 	
 		jend=1;
 		iend=1;
-		_sig=-1.;
+		_sig = -1.;
 	
 	} /* do */
 	while( jcox != 0 );
@@ -2712,7 +2712,7 @@ void c_geometry::tbf( int i, int icap )
 		
 			cx[jsnop]=1./( cdh- xxi* sdh);
 			jsno= jsnop+1;
-			ax[jsnop]=-1.;
+			ax[jsnop] = -1.;
 			return;
 		} /* if ( njun2 == 0) */
 	
@@ -2725,20 +2725,20 @@ void c_geometry::tbf( int i, int icap )
 			xxi= qp*(1.-.5* xxi)/(1.- xxi);
 		}
 	
-		qp=-( omc+ xxi* sd)/( sd*( ap+ xxi* pp)+ cd*( xxi* ap- pp));
+		qp = -( omc+ xxi* sd)/( sd*( ap+ xxi* pp)+ cd*( xxi* ap- pp));
 		d= cd- xxi* sd;
 		bx[jsnop]=( sdh+ ap* qp*( cdh- xxi* sdh))/ d;
 		cx[jsnop]=( cdh+ ap* qp*( sdh+ xxi* cdh))/ d;
 	
 		for( iend = 0; iend < njun2; iend++ )
 		{
-			ax[iend]=-ax[iend]* qp;
+			ax[iend] = -ax[iend]* qp;
 			bx[iend]= bx[iend]* qp;
-			cx[iend]=- cx[iend]* qp;
+			cx[iend] = - cx[iend]* qp;
 		}
 	
 		jsno= jsnop+1;
-		ax[jsnop]=-1.;
+		ax[jsnop] = -1.;
 		return;
 	} /* if ( njun1 == 0) */
 	
@@ -2766,14 +2766,14 @@ void c_geometry::tbf( int i, int icap )
 		}
 	
 		jsno= jsnop+1;
-		ax[jsnop]=-1.;
+		ax[jsnop] = -1.;
 		return;
 	
 	} /* if ( njun2 == 0) */
 	
 	qp= sd*( pm* pp+ aj* ap)+ cd*( pm* ap- pp* aj);
 	qm=( ap* omc- pp* sd)/ qp;
-	qp=-( aj* omc+ pm* sd)/ qp;
+	qp = -( aj* omc+ pm* sd)/ qp;
 	bx[jsnop]=( aj* qm+ ap* qp)* sdh/ sd;
 	cx[jsnop]=( aj* qm- ap* qp)* cdh/ sd;
 	
@@ -2787,13 +2787,13 @@ void c_geometry::tbf( int i, int icap )
 	jend= njun1;
 	for( iend = jend; iend < jsno; iend++ )
 	{
-		ax[iend]=- ax[iend]* qp;
+		ax[iend] = - ax[iend]* qp;
 		bx[iend]= bx[iend]* qp;
-		cx[iend]=- cx[iend]* qp;
+		cx[iend] = - cx[iend]* qp;
 	}
 	
 	jsno= jsnop+1;
-	ax[jsnop]=-1.;
+	ax[jsnop] = -1.;
 }
 
 
@@ -2810,8 +2810,8 @@ void c_geometry::trio( int j )
 	
 	if ( jcox <= PCHCON)
 	{
-		jend=-1;
-		iend=-1;
+		jend = -1;
+		iend = -1;
 	}
 	
 	if ( (jcox == 0) || (jcox > PCHCON) )
@@ -2849,9 +2849,9 @@ void c_geometry::trio( int j )
 	do
 	{
 		if ( jcox < 0 )
-			jcox=- jcox;
+			jcox = - jcox;
 		else
-			jend=- jend;
+			jend = - jend;
 		jcoxx = jcox-1;
 	
 		if ( jcox != j)
@@ -2949,9 +2949,9 @@ void c_geometry::sbf( int i, int is, nec_float *aa, nec_float *bb, nec_float *cc
 		jcox= i;
 	jcoxx = jcox-1;
 	
-	jend=-1;
-	iend=-1;
-	sig=-1.;
+	jend = -1;
+	iend = -1;
+	sig = -1.;
 	
 	do
 	{
@@ -2959,11 +2959,11 @@ void c_geometry::sbf( int i, int is, nec_float *aa, nec_float *bb, nec_float *cc
 		if ( jcox != 0 )
 		{
 			if ( jcox < 0 )
-				jcox=- jcox;
+				jcox = - jcox;
 			else
 			{
-				sig=- sig;
-				jend=- jend;
+				sig = - sig;
+				jend = - jend;
 			}
 		
 			jcoxx = jcox-1;
@@ -2988,7 +2988,7 @@ void c_geometry::sbf( int i, int is, nec_float *aa, nec_float *bb, nec_float *cc
 			{
 				*aa= aj/ sd* sig;
 				*bb= aj/(2.* cdh);
-				*cc=- aj/(2.* sdh)* sig;
+				*cc = - aj/(2.* sdh)* sig;
 				june= iend;
 			}
 		
@@ -3013,13 +3013,13 @@ void c_geometry::sbf( int i, int is, nec_float *aa, nec_float *bb, nec_float *cc
 			} /* if ( jcox != i ) */
 			else
 			if ( jcox == is)
-				*bb=- *bb;
+				*bb = - *bb;
 		
 			if ( iend == 1)
 				break;
 		} /* if ( jcox != 0 ) */
 	
-		pm=- pp;
+		pm = - pp;
 		pp=0.;
 		njun1= local_jsno;
 	
@@ -3029,7 +3029,7 @@ void c_geometry::sbf( int i, int is, nec_float *aa, nec_float *bb, nec_float *cc
 	
 		jend=1;
 		iend=1;
-		sig=-1.;
+		sig = -1.;
 	
 	} /* do */
 	while( jcox != 0 );
@@ -3056,7 +3056,7 @@ void c_geometry::sbf( int i, int is, nec_float *aa, nec_float *bb, nec_float *cc
 	{
 		if ( njun2 == 0)
 		{
-			*aa =-1.;
+			*aa = -1.;
 			qp= pi()* segment_radius[ix];
 			xxi= qp* qp;
 			xxi= qp*(1.-.5* xxi)/(1.- xxi);
@@ -3067,13 +3067,13 @@ void c_geometry::sbf( int i, int is, nec_float *aa, nec_float *bb, nec_float *cc
 		qp= pi()* segment_radius[ix];
 		xxi= qp* qp;
 		xxi= qp*(1.-.5* xxi)/(1.- xxi);
-		qp=-( omc+ xxi* sd)/( sd*( ap+ xxi* pp)+ cd*( xxi* ap- pp));
+		qp = -( omc+ xxi* sd)/( sd*( ap+ xxi* pp)+ cd*( xxi* ap- pp));
 	
 		if ( june == 1)
 		{
-			*aa=- *aa* qp;
+			*aa = - *aa* qp;
 			*bb=  *bb* qp;
-			*cc=- *cc* qp;
+			*cc = - *cc* qp;
 			if ( i != is)
 				return;
 		}
@@ -3111,7 +3111,7 @@ void c_geometry::sbf( int i, int is, nec_float *aa, nec_float *bb, nec_float *cc
 	
 	qp= sd*( pm* pp+ aj* ap)+ cd*( pm* ap- pp* aj);
 	qm=( ap* omc- pp* sd)/ qp;
-	qp=-( aj* omc+ pm* sd)/ qp;
+	qp = -( aj* omc+ pm* sd)/ qp;
 	
 	if ( june != 0 )
 	{
@@ -3123,9 +3123,9 @@ void c_geometry::sbf( int i, int is, nec_float *aa, nec_float *bb, nec_float *cc
 		}
 		else
 		{
-			*aa=- *aa* qp;
+			*aa = - *aa* qp;
 			*bb= *bb* qp;
-			*cc=- *cc* qp;
+			*cc = - *cc* qp;
 		}
 	
 		if ( i != is)

--- a/Python/PyNEC/wrap/src/c_ggrid.cpp
+++ b/Python/PyNEC/wrap/src/c_ggrid.cpp
@@ -38,7 +38,7 @@ nec_float c_ggrid::m_ysa[3] = {0.,0.,.3490658504};
 void c_ggrid::interpolate( nec_float x, nec_float y, nec_complex *f1,
     nec_complex *f2, nec_complex *f3, nec_complex *f4 )
 {
-	static int ix, iy, ixs=-10, iys=-10, igrs=-10, ixeg=0, iyeg=0;
+	static int ix, iy, ixs = -10, iys = -10, igrs = -10, ixeg=0, iyeg=0;
 	static int nxm2, nym2, nxms, nyms, nd, ndp;
 	static nec_float dx = 1., dy = 1., xs = 0., ys = 0., xz, yz;
 	static nec_complex a[4][4], b[4][4], c[4][4], d[4][4];
@@ -96,7 +96,7 @@ void c_ggrid::interpolate( nec_float x, nec_float y, nec_complex *f1,
 		ixs=(( ix-1)/3)*3+2;
 		if( ixs < 2)
 			ixs=2;
-		ixeg=-10000;
+		ixeg = -10000;
 	
 		if( ixs > nxm2)
 		{
@@ -107,7 +107,7 @@ void c_ggrid::interpolate( nec_float x, nec_float y, nec_complex *f1,
 		iys=(( iy-1)/3)*3+2;
 		if( iys < 2)
 			iys=2;
-		iyeg=-10000;
+		iyeg = -10000;
 	
 		if( iys > nym2)
 		{
@@ -314,7 +314,7 @@ void c_ggrid::sommerfeld( nec_float epr, nec_float sig, nec_float freq_mhz )
 	cl2 = -CONST4*(m_epscf-1.)/(m_epscf+1.);
 	cl1 = cl2/(m_epscf+1.);
 	ezv = m_epscf*cl1;
-	thet=-dth;
+	thet = -dth;
 	int nth = m_nya[0];
 	
 	for (int ith = 0; ith < nth; ith++ )
@@ -333,7 +333,7 @@ void c_ggrid::sommerfeld( nec_float epr, nec_float sig, nec_float freq_mhz )
 		{
 			erv=0.;
 			erh=cl2-.5*cl1;
-			eph=-erh;
+			eph = -erh;
 		}
 	
 		m_ar1[0+ith*11+  0]=erv;
@@ -365,7 +365,7 @@ nec_complex  fbar(const nec_complex& p )
 	
 		for (int i = 1; i <= 100; i++ )
 		{
-			pow=- pow* zs/ (nec_float)i;
+			pow = - pow* zs/ (nec_float)i;
 			term= pow/(2.* i+1.);
 			sum = sum + term;
 			tms = norm(term);
@@ -384,7 +384,7 @@ nec_complex  fbar(const nec_complex& p )
 	if ( real( z) < 0.)
 	{
 		minus=1;
-		z=- z;
+		z = - z;
 	}
 	else
 		minus=0;
@@ -395,13 +395,13 @@ nec_complex  fbar(const nec_complex& p )
 	
 	for (int i = 1; i <= 6; i++ )
 	{
-		term =- term*(2.*i -1.)* zs;
+		term = - term*(2.*i -1.)* zs;
 		sum += term;
 	}
 	
 	if ( minus == 1)
 		sum -= 2.0 * sqrt_pi() * z* exp( z* z);
-	fbar=- sum;
+	fbar = - sum;
 	
 	return( fbar );
 }
@@ -439,8 +439,8 @@ void gwave(nec_complex& erv, nec_complex& ezv,
 		cpp2=1.0e-20;
 	
 	cpp= sqrt( cpp2);
-	rk1=- two_pi_j()* ground_wave.r1;
-	rk2=- two_pi_j()* ground_wave.r2;
+	rk1 = - two_pi_j()* ground_wave.r1;
+	rk2 = - two_pi_j()* ground_wave.r2;
 	t1=1. -ground_wave.u2* cpp2;
 	t2= sqrt( t1);
 	t3=(1. -1./ rk1)/ rk1;
@@ -473,9 +473,9 @@ void gwave(nec_complex& erv, nec_complex& ezv,
 	x5=3.* sppp* cppp* t3* xr1;
 	x6= cpp* ground_wave.u* t2* omr* xr2/ rk2*.5;
 	x7=3.* spp* cpp* t4* xr2;
-	erv=-( x1+ x2- x3+ x4- x5+ x6- x7)* (-CONST4);
+	erv = -( x1+ x2- x3+ x4- x5+ x6- x7)* (-CONST4);
 
-	ezh=-( x1- x2+ x3- x4- x5- x6+ x7)* (-CONST4);
+	ezh = -( x1- x2+ x3- x4- x5- x6+ x7)* (-CONST4);
 
 	x1= sppp2* xr1;
 	x2= rv* spp2* xr2;
@@ -491,7 +491,7 @@ void gwave(nec_complex& erv, nec_complex& ezv,
 	x4= t3* xr1;
 	x5= t4*(1.- ground_wave.u2*(1.+ rv)- ground_wave.u2* omr* f)* xr2;
 	x6=.5* ground_wave.u2* omr*( f*( ground_wave.u2* t1- spp2-1./ rk2)+1./ rk2)* xr2/ rk2;
-	eph=-( x1- x2+ x3- x4+ x5+ x6)* (-CONST4);
+	eph = -( x1- x2+ x3- x4+ x5+ x6)* (-CONST4);
 }
 
 

--- a/Python/PyNEC/wrap/src/nec_context.cpp
+++ b/Python/PyNEC/wrap/src/nec_context.cpp
@@ -125,15 +125,15 @@ void nec_context::calc_prepare()
 	m_excitation_type = EXCITATION_VOLTAGE;
 	nload=0;
 	network_count=0;
-	m_near=-1;
-	ifar=-1;
+	m_near = -1;
+	ifar = -1;
 	ncoup=0;
 	icoup=0;
 	freq_mhz= em::speed_of_light() / 1.0e6;
 	ground.default_values();
 	nfrq=1;
-	iptflg=-2;
-	iptflq=-1;
+	iptflg = -2;
+	iptflq = -1;
 	iped=0;
 }
 
@@ -856,7 +856,7 @@ void nec_context::pt_card(int itmp1, int itmp2, int itmp3, int itmp4)
 	iptagt= itmp4;
 
 	if ( (itmp3 == 0) && (iptflg != -1) )
-		iptflg=-2;
+		iptflg = -2;
 	if ( itmp4 == 0)
 		iptagt= iptagf;
 		
@@ -871,7 +871,7 @@ void nec_context::pq_card(int itmp1, int itmp2, int itmp3, int itmp4) {
   iptaqt= itmp4;
 
   if ( (itmp3 == 0) && (iptflq != -1) )
-    iptflq=-2;
+    iptflq = -2;
   if ( itmp4 == 0)
     iptaqt= iptaqf;
 }
@@ -1095,7 +1095,7 @@ void nec_context::simulate(bool far_field_flag) {
 			xpr2  = phiss;
 	
 			if ( mhz == nfrq)
-				ifar=-1;
+				ifar = -1;
 	
 			if ( nfrq == 1)
 			{
@@ -1163,7 +1163,7 @@ void nec_context::antenna_env(void)
 	if (false == ground.type_perfect()) // if ( ground.iperf != 1)
 	{
 		if ( ground.sig < 0.)
-			ground.sig=- ground.sig/(em::impedance_over_2pi()*wavelength);
+			ground.sig = - ground.sig/(em::impedance_over_2pi()*wavelength);
 
 		nec_complex epsc = nec_complex( ground.epsr, -ground.sig*wavelength*em::impedance_over_2pi());
 		ground.zrati = 1.0/ sqrt( epsc);
@@ -2020,7 +2020,7 @@ enum excitation_return nec_context::excitation_loop(int in_freq_loop_state, int 
 					nfpat();
 
 				if ( mhz == nfrq)
-					m_near=-1;
+					m_near = -1;
 
 				if ( nfrq == 1)
 				{
@@ -2070,7 +2070,7 @@ enum excitation_return nec_context::excitation_loop(int in_freq_loop_state, int 
 		if ( (m_excitation_type == 0) || (m_excitation_type >= 4) )
 		{
 			if ( mhz == nfrq )
-				ifar=-1;
+				ifar = -1;
 
 			if ( nfrq != 1)
 			{
@@ -2476,9 +2476,9 @@ void nec_context::compute_matrix_ss( int j1, int j2, int im1, int im2,
 	i1=( im1+1)/2;
 	i2=( im2+1)/2;
 	icomp= i1*2-3;
-	ii1=-2;
+	ii1 = -2;
 	if ( icomp+2 < im1)
-		ii1=-3;
+		ii1 = -3;
 	
 	/* loop over observation patches */
 	il = -1;
@@ -2500,7 +2500,7 @@ void nec_context::compute_matrix_ss( int j1, int j2, int im1, int im2,
 		zi= m_geometry->pz[il];
 	
 		/* loop over source patches */
-		jj1=-2;
+		jj1 = -2;
 		for(int j = j1; j <= j2; j++ )
 		{
 			jl=j-1;
@@ -2520,10 +2520,10 @@ void nec_context::compute_matrix_ss( int j1, int j2, int im1, int im2,
 		
 			hintg( xi, yi, zi);
 		
-			g11=-( t2xi* exk+ t2yi* eyk+ t2zi* ezk);
-			g12=-( t2xi* exs+ t2yi* eys+ t2zi* ezs);
-			g21=-( t1xi* exk+ t1yi* eyk+ t1zi* ezk);
-			g22=-( t1xi* exs+ t1yi* eys+ t1zi* ezs);
+			g11 = -( t2xi* exk+ t2yi* eyk+ t2zi* ezk);
+			g12 = -( t2xi* exs+ t2yi* eys+ t2zi* ezs);
+			g21 = -( t1xi* exk+ t1yi* eyk+ t1zi* ezk);
+			g22 = -( t1xi* exs+ t1yi* eys+ t1zi* ezs);
 		
 			if ( i == j )
 			{
@@ -2581,7 +2581,7 @@ void nec_context::cmsw( int j1, int j2, int i1, int i2, complex_array& in_cm,
   if (itrp < 0)
     return;
 
-  int k=-1;
+  int k = -1;
   int icgo=0;
   
   /* observation loop */
@@ -2598,7 +2598,7 @@ void nec_context::cmsw( int j1, int j2, int i1, int i2, complex_array& in_cm,
     
     if ( m_geometry->icon1[i] >= PCHCON) {
       ipch= m_geometry->icon1[i]-PCHCON;
-      fsign=-1.;
+      fsign = -1.;
     }
     
     if ( m_geometry->icon2[i] >= PCHCON) {
@@ -2730,9 +2730,9 @@ void nec_context::cmws( int j, int i1, int i2, complex_array& in_cm,
       tz= m_geometry->t1z[js];
     } /* if ( (ik != 0) || (ipr == 0) ) */
 
-    etk=-( exk* tx+ eyk* ty+ ezk* tz)* m_geometry->psalp[js];
-    ets=-( exs* tx+ eys* ty+ ezs* tz)* m_geometry->psalp[js];
-    etc=-( exc* tx+ eyc* ty+ ezc* tz)* m_geometry->psalp[js];
+    etk = -( exk* tx+ eyk* ty+ ezk* tz)* m_geometry->psalp[js];
+    ets = -( exs* tx+ eys* ty+ ezs* tz)* m_geometry->psalp[js];
+    etc = -( exc* tx+ eyc* ty+ ezc* tz)* m_geometry->psalp[js];
 
     /* fill matrix elements.  element locations */
     /* determined by connection data. */
@@ -2862,7 +2862,7 @@ void nec_context::cmww( int j, int i1, int i2, complex_array& in_cm,
   } /* if ( m_use_exk == true) */
   
   /* observation loop */
-  int ipr=-1;
+  int ipr = -1;
   for( i = i1-1; i < i2; i++ ) {
     ipr++;
     xi= m_geometry->x[i];
@@ -3229,14 +3229,14 @@ void nec_context::efld( nec_float xi, nec_float yi, nec_float zi, nec_float ai, 
 			}
 			else
 			{
-				px=- yij/ xymag;
+				px = - yij/ xymag;
 				py= xij/ xymag;
 				cth= zij/ rmag;
 				zrsin= sqrt(1.0 - zratx*zratx*(1.0 - cth*cth) );
 			} /* if ( xymag <= 1.0e-6) */
 		
 			refs=( cth- zratx* zrsin)/( cth+ zratx* zrsin);
-			refps=-( zratx* cth- zrsin)/( zratx* cth+ zrsin);
+			refps = -( zratx* cth- zrsin)/( zratx* cth+ zrsin);
 			refps= refps- refs;
 			epy= px* txk+ py* tyk;
 			epx= px* epy;
@@ -3290,7 +3290,7 @@ void nec_context::efld( nec_float xi, nec_float yi, nec_float zi, nec_float ai, 
 	
 	/* displace observation point for thin wire approximation */
 	zij= zi+ zj;
-	salpr=- salpj;
+	salpr = - salpj;
 	rhox= sabj* zij- salpr* yij;
 	rhoy= salpr* xij- cabj* zij;
 	rhoz= cabj* yij- sabj* xij;
@@ -3306,7 +3306,7 @@ void nec_context::efld( nec_float xi, nec_float yi, nec_float zi, nec_float ai, 
 	{
 		rh= ai/ sqrt( rh);
 		if ( rhoz < 0.0)
-			rh=- rh;
+			rh = - rh;
 		xo= xi+ rh* rhox;
 		yo= yi+ rh* rhoy;
 		zo= zi+ rh* rhoz;
@@ -3395,7 +3395,7 @@ void nec_context::eksc( nec_float s, nec_float z, nec_float rh, nec_float xk, in
 	nec_float ss = sin(shk);
 	nec_float cs = cos(shk);
 	nec_float z2a = sh - z;
-	nec_float z1a =-(sh + z);
+	nec_float z1a = -(sh + z);
 	
 	nec_complex gz1, gz2, gp1, gp2;
 	gx( z1a, rh, xk, &gz1, &gp1);
@@ -3404,21 +3404,21 @@ void nec_context::eksc( nec_float s, nec_float z, nec_float rh, nec_float xk, in
 	nec_complex gzp2 = gp2 * z2a;
 	
 	*in_ezs=  __const1*(( gz2- gz1)* cs* xk-( gzp2+ gzp1)* ss);
-	*in_ezc=- __const1*(( gz2+ gz1)* ss* xk+( gzp2- gzp1)* cs);
+	*in_ezc = - __const1*(( gz2+ gz1)* ss* xk+( gzp2- gzp1)* cs);
 	*erk= __const1*( gp2- gp1)* rh;
 	
 	nec_float cint, sint;
 	intx(-shk, shk, rhk, ij, &cint, &sint);
-	*in_ezk=- __const1*( gzp2- gzp1+ xk* xk* nec_complex( cint,- sint));
+	*in_ezk = - __const1*( gzp2- gzp1+ xk* xk* nec_complex( cint,- sint));
 	
 	if ( rh >= 1.0e-10)
 	{
 		gzp1 = gzp1 * z1a;
 		gzp2 = gzp2 * z2a;
 		
-		*ers =- __const1*(( gzp2+ gzp1+ gz2+ gz1)*
+		*ers = - __const1*(( gzp2+ gzp1+ gz2+ gz1)*
 			ss-( z2a* gz2- z1a* gz1)* cs*xk)/ rh;
-		*erc =- __const1*(( gzp2- gzp1+ gz2- gz1)*
+		*erc = - __const1*(( gzp2- gzp1+ gz2- gz1)*
 			cs+( z2a* gz2+ z1a* gz1)* ss*xk)/ rh;
 		return;
 	}
@@ -3470,7 +3470,7 @@ void nec_context::ekscx( nec_float bx, nec_float s, nec_float z,
 	ss= sin( shk);
 	cs= cos( shk);
 	z2a= sh- z;
-	z1a=-( sh+ z);
+	z1a = -( sh+ z);
 	a2= b* b;
 	
 	if ( inx1 != 2)
@@ -3498,16 +3498,16 @@ void nec_context::ekscx( nec_float bx, nec_float s, nec_float z,
 	}
 	
 	*in_ezs= __const1*(( gz2- gz1)* cs* xk-( gzp2+ gzp1)* ss);
-	*in_ezc=- __const1*(( gz2+ gz1)* ss* xk+( gzp2- gzp1)* cs);
-	*ers=- __const1*(( z2a* grp2+ z1a* grp1+ gr2+ gr1)*ss
+	*in_ezc = - __const1*(( gz2+ gz1)* ss* xk+( gzp2- gzp1)* cs);
+	*ers = - __const1*(( z2a* grp2+ z1a* grp1+ gr2+ gr1)*ss
 		-( z2a* gr2- z1a* gr1)* cs* xk);
-	*erc=- __const1*(( z2a* grp2- z1a* grp1+ gr2- gr1)*cs
+	*erc = - __const1*(( z2a* grp2- z1a* grp1+ gr2- gr1)*cs
 		+( z2a* gr2+ z1a* gr1)* ss* xk);
 	*erk= __const1*( grk2- grk1);
 	intx(- shk, shk, rhk, ij, &cint, &sint);
 	bk= b* xk;
 	bk2= bk* bk*.25;
-	*in_ezk=- __const1*( gzp2- gzp1+ xk* xk*(1.- bk2)*
+	*in_ezk = - __const1*( gzp2- gzp1+ xk* xk*(1.- bk2)*
 		nec_complex( cint,- sint)-bk2*( gzz2- gzz1));
 }
 
@@ -3568,10 +3568,10 @@ void nec_context::etmns( nec_float p1, nec_float p2, nec_float p3, nec_float p4,
 		set= sin( p3);
 		pxl= cth* cph* cet- sph* set;
 		pyl= cth* sph* cet+ cph* set;
-		pzl=- sth* cet;
-		wx=- sth* cph;
-		wy=- sth* sph;
-		wz=- cth;
+		pzl = - sth* cet;
+		wx = - sth* cph;
+		wy = - sth* sph;
+		wz = - cth;
 		qx= wy* pzl- wz* pyl;
 		qy= wz* pxl- wx* pzl;
 		qz= wx* pyl- wy* pxl;
@@ -3580,8 +3580,8 @@ void nec_context::etmns( nec_float p1, nec_float p2, nec_float p3, nec_float p4,
 		{
 			if (ground.type_perfect())
 			{
-				rrv=-cplx_10();
-				rrh=-cplx_10();
+				rrv = -cplx_10();
+				rrh = -cplx_10();
 			}
 			else
 			{
@@ -3589,7 +3589,7 @@ void nec_context::etmns( nec_float p1, nec_float p2, nec_float p3, nec_float p4,
 				rrh= ground.zrati* cth;
 				rrh=( rrh- rrv)/( rrh+ rrv);
 				rrv= ground.zrati* rrv;
-				rrv=-( cth- rrv)/( cth+ rrv);
+				rrv = -( cth- rrv)/( cth+ rrv);
 			}
 		}
 	
@@ -3599,7 +3599,7 @@ void nec_context::etmns( nec_float p1, nec_float p2, nec_float p3, nec_float p4,
 			{
 				for (int i = 0; i < n; i++ )
 				{
-					nec_float arg=- two_pi() *( wx* m_geometry->x[i]+ wy* m_geometry->y[i]+ wz* m_geometry->z[i]);
+					nec_float arg = - two_pi() *( wx* m_geometry->x[i]+ wy* m_geometry->y[i]+ wz* m_geometry->z[i]);
 					nec_complex e_amplitude(cos(arg), sin(arg));
 					
 					e[i] = -(pxl*m_geometry->cab[i]+ pyl*m_geometry->sab[i]+ pzl*m_geometry->salp[i]) * e_amplitude * incident_amplitude;
@@ -3610,11 +3610,11 @@ void nec_context::etmns( nec_float p1, nec_float p2, nec_float p3, nec_float p4,
 					tt1=( pyl* cph- pxl* sph)*( rrh- rrv);
 					nec_complex cx= rrv* pxl- tt1* sph;
 					nec_complex cy= rrv* pyl+ tt1* cph;
-					nec_complex cz=- rrv* pzl;
+					nec_complex cz = - rrv* pzl;
 				
 					for (int i = 0; i < n; i++ )
 					{
-						nec_float arg=- two_pi()*( wx* m_geometry->x[i]+ wy* m_geometry->y[i]- wz* m_geometry->z[i]);
+						nec_float arg = - two_pi()*( wx* m_geometry->x[i]+ wy* m_geometry->y[i]- wz* m_geometry->z[i]);
 						nec_complex e_amplitude(cos(arg), sin(arg));
 						e[i] -= ( cx* m_geometry->cab[i]+ cy* m_geometry->sab[i]+ cz* m_geometry->salp[i])* e_amplitude * incident_amplitude;
 					}
@@ -3645,8 +3645,8 @@ void nec_context::etmns( nec_float p1, nec_float p2, nec_float p3, nec_float p4,
 			if (ground.present())
 			{
 				tt1=( qy* cph- qx* sph)*( rrv- rrh);
-				nec_complex cx=-( rrh* qx- tt1* sph);
-				nec_complex cy=-( rrh* qy+ tt1* cph);
+				nec_complex cx = -( rrh* qx- tt1* sph);
+				nec_complex cy = -( rrh* qy+ tt1* cph);
 				nec_complex cz= rrh* qz;
 				
 				int i= -1;
@@ -3669,9 +3669,9 @@ void nec_context::etmns( nec_float p1, nec_float p2, nec_float p3, nec_float p4,
 		} /* if ( excite_type == EXCITATION_LINEAR) */
 
 		/* incident plane wave, elliptic polarization. */
-		tt1=-(cplx_01())* p6;
+		tt1 = -(cplx_01())* p6;
 		if ( excite_type == EXCITATION_CIRC_LEFT)
-			tt1=- tt1;
+			tt1 = - tt1;
 	
 		if ( n != 0)
 		{
@@ -3681,7 +3681,7 @@ void nec_context::etmns( nec_float p1, nec_float p2, nec_float p3, nec_float p4,
 		
 			for (int i = 0; i < n; i++ )
 			{
-				nec_float arg=- two_pi()*( wx* m_geometry->x[i]+ wy* m_geometry->y[i]+ wz* m_geometry->z[i]);
+				nec_float arg = - two_pi()*( wx* m_geometry->x[i]+ wy* m_geometry->y[i]+ wz* m_geometry->z[i]);
 				nec_complex e_amplitude(cos(arg), sin(arg));
 				e[i] = -(cx* m_geometry->cab[i] + cy* m_geometry->sab[i] + cz*m_geometry->salp[i])* e_amplitude * incident_amplitude;
 			}
@@ -3692,11 +3692,11 @@ void nec_context::etmns( nec_float p1, nec_float p2, nec_float p3, nec_float p4,
 				tt2=( cy* cph- cx* sph)*( rrh- rrv);
 				nec_complex ccx= rrv* cx- tt2* sph;
 				nec_complex ccy= rrv* cy+ tt2* cph;
-				nec_complex ccz=- rrv* cz;
+				nec_complex ccz = - rrv* cz;
 			
 				for (int i = 0; i < n; i++ )
 				{
-					nec_float arg=- two_pi()*( wx* m_geometry->x[i]+ wy* m_geometry->y[i]- wz* m_geometry->z[i]);
+					nec_float arg = - two_pi()*( wx* m_geometry->x[i]+ wy* m_geometry->y[i]- wz* m_geometry->z[i]);
 					nec_complex e_amplitude(cos(arg), sin(arg));
 					e[i] -= (ccx* m_geometry->cab[i]+ ccy* m_geometry->sab[i]+ ccz* m_geometry->salp[i]) * e_amplitude * incident_amplitude;
 				}
@@ -3732,8 +3732,8 @@ void nec_context::etmns( nec_float p1, nec_float p2, nec_float p3, nec_float p4,
 		if (ground.present())
 		{
 			tt1=( cy* cph- cx* sph)*( rrv- rrh);
-			cx=-( rrh* cx- tt1* sph);
-			cy=-( rrh* cy+ tt1* cph);
+			cx = -( rrh* cx- tt1* sph);
+			cy = -( rrh* cy+ tt1* cph);
 			cz= rrh* cz;
 
 			int i= -1;
@@ -3956,7 +3956,7 @@ void nec_context::gxx( nec_float zz, nec_float rh, nec_float a, nec_float a2, ne
 	if ( ira != 1)
 	{
 		*g3=( *g3+ *gzp)* rh;
-		*gzp=- zz* c1* gz;
+		*gzp = - zz* c1* gz;
 	
 		if ( rh <= 1.0e-10)
 		{
@@ -3971,11 +3971,11 @@ void nec_context::gxx( nec_float zz, nec_float rh, nec_float a, nec_float a2, ne
 	} /* if ( ira != 1) */
 	
 	t2=.5* a;
-	*g2=- t2* c1* gz;
+	*g2 = - t2* c1* gz;
 	*g2p= t2* gz* c2/ r2;
 	*g3= rh2* *g2p- a* gz* c1;
 	*g2p= *g2p* zz;
-	*gzp=- zz* c1* gz;
+	*gzp = - zz* c1* gz;
 }
 
 /*-----------------------------------------------------------------------*/
@@ -4137,7 +4137,7 @@ void nec_context::hintg( nec_float xi, nec_float yi, nec_float zi )
 	
 	rx= xi- xj;
 	ry= yi- yj;
-	rfl=-1.;
+	rfl = -1.;
 	exk=cplx_00();
 	eyk=cplx_00();
 	ezk=cplx_00();
@@ -4147,7 +4147,7 @@ void nec_context::hintg( nec_float xi, nec_float yi, nec_float zi )
 	
 	for (int ground_loop = 1; ground_loop <= ground.ksymp; ground_loop++ )
 	{
-		rfl=- rfl;
+		rfl = - rfl;
 		rz = zi - zj*rfl;
 		rsq = rx*rx + ry*ry + rz*rz;
 	
@@ -4158,7 +4158,7 @@ void nec_context::hintg( nec_float xi, nec_float yi, nec_float zi )
 		rk= two_pi() * r;
 		cr= cos( rk);
 		sr= sin( rk);
-		gam=-( nec_complex(cr,-sr)+rk*nec_complex(sr,cr) )/( four_pi()*rsq*r )* m_s;
+		gam = -( nec_complex(cr,-sr)+rk*nec_complex(sr,cr) )/( four_pi()*rsq*r )* m_s;
 		exc= gam* rx;
 		eyc= gam* ry;
 		ezc= gam* rz;
@@ -4175,12 +4175,12 @@ void nec_context::hintg( nec_float xi, nec_float yi, nec_float zi )
 		{
 			if (  ground.type_perfect() ) //ground.iperf == 1)
 			{
-				f1x=- f1x;
-				f1y=- f1y;
-				f1z=- f1z;
-				f2x=- f2x;
-				f2y=- f2y;
-				f2z=- f2z;
+				f1x = - f1x;
+				f1y = - f1y;
+				f1z = - f1z;
+				f2x = - f2x;
+				f2y = - f2y;
+				f2z = - f2z;
 			}
 			else
 			{
@@ -4194,7 +4194,7 @@ void nec_context::hintg( nec_float xi, nec_float yi, nec_float zi )
 				}
 				else
 				{
-					pxx=- ry/ xymag;
+					pxx = - ry/ xymag;
 					pyy= rx/ xymag;
 					cth= rz/ r;
 					rrv= sqrt(1.0 - ground.get_zrati_sqr() *(1.0 - cth* cth));
@@ -4203,7 +4203,7 @@ void nec_context::hintg( nec_float xi, nec_float yi, nec_float zi )
 				rrh= ground.zrati* cth;
 				rrh=( rrh- rrv)/( rrh+ rrv);
 				rrv= ground.zrati* rrv;
-				rrv=-( cth- rrv)/( cth+ rrv);
+				rrv = -( cth- rrv)/( cth+ rrv);
 				
 				gam=( f1x* pxx+ f1y* pyy)*( rrv- rrh);
 				f1x= f1x* rrh+ gam* pxx;
@@ -4238,11 +4238,11 @@ void nec_context::hsfld( nec_float xi, nec_float yi, nec_float zi, nec_float ai 
 	
 	xij= xi- xj;
 	yij= yi- yj;
-	rfl=-1.;
+	rfl = -1.;
 	
 	for (int ground_loop = 0; ground_loop < ground.ksymp; ground_loop++ )
 	{
-		rfl=- rfl;
+		rfl = - rfl;
 		salpr= salpj* rfl;
 		zij= zi- rfl* zj;
 		zp= xij* cabj+ yij* sabj+ zij* salpr;
@@ -4306,14 +4306,14 @@ void nec_context::hsfld( nec_float xi, nec_float yi, nec_float zi, nec_float ai 
 				}
 				else
 				{
-					px=- yij/ xymag;
+					px = - yij/ xymag;
 					py= xij/ xymag;
 					cth= zij/ rmag;
 					rrv= sqrt(1.- zratx* zratx*(1.- cth* cth));
 				}
 			
 				rrh= zratx* cth;
-				rrh=-( rrh- rrv)/( rrh+ rrv);
+				rrh = -( rrh- rrv)/( rrh+ rrv);
 				rrv= zratx* rrv;
 				rrv=( cth- rrv)/( cth+ rrv);
 				qy=( phx* px+ phy* py)*( rrv- rrh);
@@ -4380,8 +4380,8 @@ void nec_context::hsflx( nec_float s, nec_float rh, nec_float zpx,
 		}
 		else
 		{
-			zp=- zpx;
-			hss=-1.;
+			zp = - zpx;
+			hss = -1.;
 		}
 	
 		dh= 0.5* s;
@@ -4408,8 +4408,8 @@ void nec_context::hsflx( nec_float s, nec_float rh, nec_float zpx,
 			t1= z1* ekr1/ r1;
 			t2= z2a* ekr2/ r2;
 			*hps=( cdk*( ekr2- ekr1)- cplx_01()* sdk*( t2+ t1))* hss;
-			*hpc=- sdk*( ekr2+ ekr1)- cplx_01()* cdk*( t2- t1);
-			cons=- cplx_01()/(2.0 * two_pi() * rh);
+			*hpc = - sdk*( ekr2+ ekr1)- cplx_01()* cdk*( t2- t1);
+			cons = - cplx_01()/(2.0 * two_pi() * rh);
 			*hps= cons* *hps;
 			*hpc= cons* *hpc;
 			return;
@@ -4978,7 +4978,7 @@ void nec_context::netwk( complex_array& in_cm, int_array& in_ip,
 					y12r=0.;
 					y12i=1./( x11r[j]* sin( y22r));
 					y11r= x12r[j];
-					y11i=- y12i* cos( y22r);
+					y11i = - y12i* cos( y22r);
 					y22r= x22r[j];
 					y22i= y11i+ x22i[j];
 					y11i= y11i+ x12i[j];
@@ -5004,7 +5004,7 @@ void nec_context::netwk( complex_array& in_cm, int_array& in_ip,
 				jump2 = false;
 				if ( ! jump1 )
 				{
-					isc1=-1;
+					isc1 = -1;
 			
 					for( i = 0; i < nteq; i++ )
 					{
@@ -5059,7 +5059,7 @@ void nec_context::netwk( complex_array& in_cm, int_array& in_ip,
 				jump2 = false;
 				if ( ! jump1 )
 				{
-					isc2=-1;
+					isc2 = -1;
 			
 					for( i = 0; i < nteq; i++ )
 					{
@@ -5862,7 +5862,7 @@ void nec_context::qdsrc( int is, nec_complex v, complex_array& e )
     if (ipr > PCHCON)
       ind1=2;
     else if ( ipr < 0 ) {
-      ipr=- ipr;
+      ipr = - ipr;
       ipr--;
       if ( -m_geometry->icon1[ipr-1] != jp1 ) {
         ind1=2;
@@ -6562,7 +6562,7 @@ void nec_context::unere( nec_float xob, nec_float yob, nec_float zob, bool groun
 	
 	if ( ground_reflection)
 	{
-		zr =- zr;
+		zr = - zr;
 		t1zr = -t1zr;
 		t2zr = -t2zr;
 	}
@@ -6605,13 +6605,13 @@ void nec_context::unere( nec_float xob, nec_float yob, nec_float zob, bool groun
 	// handle the ground_reflection
 	if (  ground.type_perfect() ) // (ground.iperf == 1)
 	{
-		exk=- exk;
-		eyk=- eyk;	
+		exk = - exk;
+		eyk = - eyk;	
 		
-		ezk=- ezk;
-		exs=- exs;
-		eys=- eys;
-		ezs=- ezs;
+		ezk = - ezk;
+		exs = - exs;
+		eys = - eys;
+		ezs = - ezs;
 		return;
 	}
 	
@@ -6625,7 +6625,7 @@ void nec_context::unere( nec_float xob, nec_float yob, nec_float zob, bool groun
 	}
 	else
 	{
-		px=- ry/ xymag;
+		px = - ry/ xymag;
 		py= rx/ xymag;
 		cth= rz/ sqrt( xymag* xymag+ rz* rz);
 		rrv= sqrt(1.0- ground.get_zrati_sqr() * (1.0 - cth*cth));
@@ -6634,7 +6634,7 @@ void nec_context::unere( nec_float xob, nec_float yob, nec_float zob, bool groun
 	rrh= ground.zrati* cth;
 	rrh=( rrh- rrv)/( rrh+ rrv);
 	rrv= ground.zrati* rrv;
-	rrv=-( cth- rrv)/( cth+ rrv);
+	rrv = -( cth- rrv)/( cth+ rrv);
 	
 	edp=( exk* px+ eyk* py)*( rrh- rrv);
 	exk= exk* rrv+ edp* px;
@@ -6873,7 +6873,7 @@ void nec_context::fblock( int nrow, int ncol, int imax, int ipsym )
 			{
 				nec_complex deter = symmetry_array[i+j*nop];
 				symmetry_array[i+(j+kk)*nop] = deter;
-				symmetry_array[i+kk+(j+kk)*nop] =- deter;
+				symmetry_array[i+kk+(j+kk)*nop] = - deter;
 				symmetry_array[i+kk+j*nop] = deter;
 			}
 		}
@@ -6918,10 +6918,10 @@ void nec_context::gfld(nec_float rho, nec_float phi, nec_float rz,
 	
 	/* computation of space and ground waves. */
 	ground_wave.set_u(ground.zrati);
-	phx=- sin( phi);
+	phx = - sin( phi);
 	phy= cos( phi);
 	rx= rho* phy;
-	ry=- rho* phx;
+	ry = - rho* phx;
 	cix=cplx_00();
 	ciy=cplx_00();
 	ciz=cplx_00();
@@ -6964,19 +6964,19 @@ void nec_context::gfld(nec_float rho, nec_float phi, nec_float rz,
 		}
 	
 		el= pi()* m_geometry->segment_length[i];
-		rfl=-1.;
+		rfl = -1.;
 	
 		/* Integration of (current)*(phase factor) over segment and image for 
 		   constant, sine, and cosine current distributions */
 		for( k = 0; k < 2; k++ )
 		{
-			rfl=- rfl;
+			rfl = - rfl;
 			riz= rz- m_geometry->z[i]* rfl;
 			rxyz= sqrt( rix* rix+ riy* riy+ riz* riz);
 			rnx= rix/ rxyz;
 			rny= riy/ rxyz;
 			rnz= riz/ rxyz;
-			omega=-( rnx* dx+ rny* dy+ rnz* dz* rfl);
+			omega = -( rnx* dx+ rny* dy+ rnz* dz* rfl);
 			sill= omega* el;
 			top= el+ sill;
 			bot= el- sill;
@@ -7040,8 +7040,8 @@ void nec_context::gfld(nec_float rho, nec_float phi, nec_float rz,
 	rny= ry/ r;
 	rnz= rz/ r;
 	thx= rnz* phy;
-	thy=- rnz* phx;
-	thz=- rho/ r;
+	thy = - rnz* phx;
+	thz = - rho/ r;
 	*eth= cix* thx+ ciy* thy+ ciz* thz;
 	*epi= cix* phx+ ciy* phy;
 	*erd= cix* rnx+ ciy* rny+ ciz* rnz;
@@ -7063,14 +7063,14 @@ void nec_context::ffld(nec_float thet, nec_float phi,
 	nec_complex zrsin, rrv, rrh, rrv1, rrh1, rrv2, rrh2;
 	nec_complex tix, tiy, tiz, zscrn, ex, ey, ez;
 	
-	phx=- sin( phi);
+	phx = - sin( phi);
 	phy= cos( phi);
 	roz= cos( thet);
 	rozs= roz;
 	thx= roz* phy;
-	thy=- roz* phx;
-	thz=- sin( thet);
-	rox=- thz* phy;
+	thy = - roz* phx;
+	thz = - sin( thet);
+	rox = - thz* phy;
 	roy= thz* phx;
 	
 	jump = false;
@@ -7085,14 +7085,14 @@ void nec_context::ffld(nec_float thet, nec_float phi,
 		/* for perfect ground */
 		if (ground.type_perfect())
 		{
-			rrv=-cplx_10();
-			rrh=-cplx_10();
+			rrv = -cplx_10();
+			rrh = -cplx_10();
 		}
 		else
 		{
 			/* for infinite planar ground */
 			zrsin= sqrt(1.- ground.get_zrati_sqr() * thz* thz);
-			rrv=-( roz- ground.zrati * zrsin)/( roz+ ground.zrati* zrsin);
+			rrv = -( roz- ground.zrati * zrsin)/( roz+ ground.zrati* zrsin);
 			rrh=( ground.zrati* roz- zrsin)/( ground.zrati* roz+ zrsin);
 		}
 	
@@ -7108,13 +7108,13 @@ void nec_context::ffld(nec_float thet, nec_float phi,
 				nec_complex zrati2 = ground.get_zrati2(_wavelength);
 				
 				zrsin = sqrt(1.-  zrati2 *  zrati2 * thz* thz);
-				rrv2 =-( roz-  zrati2* zrsin)/( roz+  zrati2* zrsin);
+				rrv2 = -( roz-  zrati2* zrsin)/( roz+  zrati2* zrsin);
 				rrh2 =(  zrati2* roz- zrsin)/(  zrati2* roz+ zrsin);
 				darg = -two_pi() * 2.0 * ground.get_ch(_wavelength) * roz;
 			}
 		} /* if ( ifar > 1) */
 	
-		roz=- roz;
+		roz = - roz;
 		ccx= cix;
 		ccy= ciy;
 		ccz= ciz;
@@ -7128,7 +7128,7 @@ void nec_context::ffld(nec_float thet, nec_float phi,
 		/* loop over structure segments */
 		for( i = 0; i < m_geometry->n_segments; i++ )
 		{
-		omega=-( rox* m_geometry->cab[i]+ roy* m_geometry->sab[i]+ roz* m_geometry->salp[i]);
+		omega = -( rox* m_geometry->cab[i]+ roy* m_geometry->sab[i]+ roz* m_geometry->salp[i]);
 		el= pi()* m_geometry->segment_length[i];
 		sill= omega* el;
 		top= el+ sill;
@@ -7326,7 +7326,7 @@ void nec_context::ffld(nec_float thet, nec_float phi,
 			rrh= ground.zrati * roz;
 			rrh=( rrh- rrv)/( rrh+ rrv);
 			rrv= ground.zrati * rrv;
-			rrv=-( roz- rrv)/( roz+ rrv);
+			rrv = -( roz- rrv)/( roz+ rrv);
 			
 			*eth=( tempx* phx+ tempy* phy)*( rrh- rrv);
 			tempx= tempx* rrv+ *eth* phx;

--- a/Python/PyNEC/wrap/src/nec_radiation_pattern.cpp
+++ b/Python/PyNEC/wrap/src/nec_radiation_pattern.cpp
@@ -292,7 +292,7 @@ void nec_radiation_pattern::analyze(nec_context* m_context)
 	{
 		exrm=1./ m_range;
 		exra= m_range/ _wavelength;
-		exra=-360.*( exra- floor( exra));
+		exra = -360.*( exra- floor( exra));
 	}
 	
 	int result_counter=0;
@@ -366,7 +366,7 @@ void nec_radiation_pattern::analyze(nec_context* m_context)
 					stilta= sin( tilta);
 					tstor1= tstor1* stilta* stilta;
 					tstor2= tstor2* stilta* cos( tilta);
-					emajr2=- tstor1+ tstor2+ ethm2;
+					emajr2 = - tstor1+ tstor2+ ethm2;
 					eminr2= tstor1- tstor2+ ephm2;
 					if ( eminr2 < 0.)
 						eminr2=0.;

--- a/Python/PyNEC/wrap/src/net_solve.cpp
+++ b/Python/PyNEC/wrap/src/net_solve.cpp
@@ -267,15 +267,15 @@ void c_network::net_solve( complex_array& cm, nec_complex *cmb,
 					y12r=0.;
 					y12i=1./( x11r[j]* sin( y22r));
 					y11r= x12r[j];
-					y11i=- y12i* cos( y22r);
+					y11i = - y12i* cos( y22r);
 					y22r= x22r[j];
 					y22i= y11i+ x22i[j];
 					y11i= y11i+ x12i[j];
 				
 					if ( ntyp[j] != 2)
 					{
-						y12r=- y12r;
-						y12i=- y12i;
+						y12r = - y12r;
+						y12i = - y12i;
 					}
 				} /* if ( ntyp[j] <= 1) */
 		
@@ -293,7 +293,7 @@ void c_network::net_solve( complex_array& cm, nec_complex *cmb,
 				jump2 = false;
 				if ( ! jump1 )
 				{
-					isc1=-1;
+					isc1 = -1;
 			
 					for( i = 0; i < nteq; i++ )
 					{
@@ -348,7 +348,7 @@ void c_network::net_solve( complex_array& cm, nec_complex *cmb,
 				jump2 = false;
 				if ( ! jump1 )
 				{
-					isc2=-1;
+					isc2 = -1;
 			
 					for( i = 0; i < nteq; i++ )
 					{

--- a/src/atlas_check.cpp
+++ b/src/atlas_check.cpp
@@ -513,7 +513,7 @@ void matrix_setup(complex_array& A)
 {	int n = 4;
 	A.get(0,0) = 3.0;
 	A.get(0,1) =1.0;
-	A.get(0,2) =-4.0;
+	A.get(0,2) = -4.0;
 	A.get(0,3) =2.0;
 	A.get(1,0) =3.0;
 	A.get(1,1) =1.0;
@@ -521,11 +521,11 @@ void matrix_setup(complex_array& A)
 	A.get(1,3) =2.0;
 	A.get(2,0) =2.0;
 	A.get(2,1) =13.0;
-	A.get(2,2) =-1.0;
+	A.get(2,2) = -1.0;
 	A.get(2,3) =0.0;
-	A.get(3,0) =-2.0;
+	A.get(3,0) = -2.0;
 	A.get(3,1) =3.0;
-	A.get(3,2) =-1.0;
+	A.get(3,2) = -1.0;
 	A.get(3,3) =4.0;
 	for (int i = 1; i < n; i++ )
 	{

--- a/src/c_evlcom.cpp
+++ b/src/c_evlcom.cpp
@@ -404,11 +404,11 @@ void c_evlcom::saoa( nec_float t, complex_array& ans)
 		com=xl-m_ck1;
 		cgam1=sqrt(xl+m_ck1)*sqrt(com);
 		if (real(com) < 0. && imag(com) >= 0.)
-			cgam1=-cgam1;
+			cgam1 = -cgam1;
 		com=xl-m_ck2;
 		cgam2=sqrt(xl+m_ck2)*sqrt(com);
 		if (real(com) < 0. && imag(com) >= 0.)
-			cgam2=-cgam2;
+			cgam2 = -cgam2;
 	}
 	
 	if (norm(xl) >= m_tsmag)
@@ -429,7 +429,7 @@ void c_evlcom::saoa( nec_float t, complex_array& ans)
 			}
 			else
 			{
-				nec_float sign=-1.0;
+				nec_float sign = -1.0;
 				dgam=1.0/(xl*xl);
 				dgam=sign*((m_ct3*dgam+m_ct2)*dgam+m_ct1)/xl;
 			} /* if (xlr >= m_ck2) */
@@ -472,17 +472,17 @@ void c_evlcom::saoa( nec_float t, complex_array& ans)
 	if (m_rho != 0.)
 	{
 		b0p=b0p/m_rho;
-		ans[0]=-com*xl*(b0p+b0*xl);
+		ans[0] = -com*xl*(b0p+b0*xl);
 		ans[3]=com*xl*b0p;
 	}
 	else
 	{
-		ans[0]=-com*xl*xl*.5;
+		ans[0] = -com*xl*xl*.5;
 		ans[3]=ans[0];
 	}
 	
 	ans[1]=com*cgam2*cgam2*b0;
-	ans[2]=-ans[3]*cgam2*m_rho;
+	ans[2] = -ans[3]*cgam2*m_rho;
 	ans[4]=com*b0;
 }
 
@@ -531,7 +531,7 @@ void c_evlcom::evlua( nec_complex *erv, nec_complex *ezv,
 		*erv=conj(m_ck1sq*ans[2]);
 		*ezv=conj(m_ck1sq*(ans[1]+m_ck2sq*ans[4]));
 		*erh=conj(m_ck2sq*(ans[0]+ans[5]));
-		*eph=-conj(m_ck2sq*(ans[3]+ans[5]));
+		*eph = -conj(m_ck2sq*(ans[3]+ans[5]));
 		
 		return;	
 	} /* if (m_zph >= 2.*m_rho) */
@@ -549,7 +549,7 @@ void c_evlcom::evlua( nec_complex *erv, nec_complex *ezv,
 	rom1(6,ans,2);
 	
 	for (int i = 0; i < 6; i++ )
-		sum[i]=-(sum[i]+ans[i]);
+		sum[i] = -(sum[i]+ans[i]);
 	
 	/* path from imaginary axis to -infinity */
 	if (m_zph > .001*m_rho)
@@ -559,7 +559,7 @@ void c_evlcom::evlua( nec_complex *erv, nec_complex *ezv,
 	
 	del=PTP/del;
 	delta=nec_complex(-1.0,slope)*del/sqrt(1.+slope*slope);
-	delta2=-conj(delta);
+	delta2 = -conj(delta);
 	gshank(cp1,delta,ans,6,sum,0,bk,bk);
 	rmis=m_rho*(real(m_ck1)-m_ck2);
 	
@@ -569,7 +569,7 @@ void c_evlcom::evlua( nec_complex *erv, nec_complex *ezv,
 		if (m_zph >= 1.e-10)
 		{
 			bk=nec_complex(-m_zph,m_rho)*(m_ck1-cp3);
-			rmis=-real(bk)/fabs(imag(bk));
+			rmis = -real(bk)/fabs(imag(bk));
 			if (rmis > 4.*m_rho/m_zph)
 				jump = true;
 		}
@@ -600,7 +600,7 @@ void c_evlcom::evlua( nec_complex *erv, nec_complex *ezv,
 	{
 		/* integrate below branch points, then to + infinity */
 		for (int i = 0; i < 6; i++ )
-			sum[i]=-ans[i];
+			sum[i] = -ans[i];
 		
 		rmis=real(m_ck1)*1.01;
 		if ( (m_ck2+1.) > rmis )
@@ -618,7 +618,7 @@ void c_evlcom::evlua( nec_complex *erv, nec_complex *ezv,
 	*erv=conj(m_ck1sq*ans[2]);
 	*ezv=conj(m_ck1sq*(ans[1]+m_ck2sq*ans[4]));
 	*erh=conj(m_ck2sq*(ans[0]+ans[5]));
-	*eph=-conj(m_ck2sq*(ans[3]+ans[5]));
+	*eph = -conj(m_ck2sq*(ans[3]+ans[5]));
 }
 
 /*-----------------------------------------------------------------------*/
@@ -675,7 +675,7 @@ void bessel( nec_complex z, nec_complex *j0, nec_complex *j0p )
   if (zms <= 1.e-12)
   {
     *j0=cplx_10;
-    *j0p=-0.5*z;
+    *j0p = -0.5*z;
     return;
   }
   
@@ -750,11 +750,11 @@ void hankel( nec_complex z, nec_complex *h0, nec_complex *h0p )
 	/* initialization of constants */
 	if ( ! hankel_init )
 	{
-		nec_float psi=-GAMMA;
+		nec_float psi = -GAMMA;
 		for (int k = 1; k <= 25; k++ )
 		{
 			int i = k-1;
-			a1[i]=-.25/(k*k);
+			a1[i] = -.25/(k*k);
 			a2[i]=1.0/(k+1.0);
 			psi += 1.0/k;
 			a3[i]=psi+psi;

--- a/src/c_geometry.cpp
+++ b/src/c_geometry.cpp
@@ -238,7 +238,7 @@ void c_geometry::parse_geometry(nec_context* in_context, FILE* input_fp )
         "\n  STRUCTURE ROTATED ABOUT Z-AXIS %d TIMES"
         " - LABELS INCREMENTED BY %d\n", card_int_2, card_int_1 );
     
-      int ix=-1;
+      int ix = -1;
       int iy = 0;
       int iz = 0;
       reflect( ix, iy, iz, card_int_1, card_int_2);
@@ -566,7 +566,7 @@ void c_geometry::geometry_complete(nec_context* in_context, int gpflag)
       if ( xw2 > 1.)
         xw2=1.;
       if ( xw2 < -1.)
-        xw2=-1.;
+        xw2 = -1.;
   
       salp[i]= xw2;
       xw2= rad_to_degrees(asin( xw2));
@@ -912,7 +912,7 @@ void c_geometry::move( nec_float rox, nec_float roy, nec_float roz, nec_float xs
   yx= sph* cth;
   yy= sph* sth* sps+ cph* cps;
   yz= sph* sth* cps- cph* sps;
-  zx=- sth;
+  zx = - sth;
   zy= cth* sps;
   zz= cth* cps;
 
@@ -1091,10 +1091,10 @@ void c_geometry::reflect( int ix, int iy, int iz, int itx, int nop ) {
   
     x[nx]= x[i];
     y[nx]= y[i];
-    z[nx]=- e1;
+    z[nx] = - e1;
     x2[nx]= x2[i];
     y2[nx]= y2[i];
-    z2[nx]=- e2;
+    z2[nx] = - e2;
     itagi= segment_tags[i];
   
     if ( itagi == 0)
@@ -1140,14 +1140,14 @@ void c_geometry::reflect( int ix, int iy, int iz, int itx, int nop ) {
   
       px[nx]= px[i];
       py[nx]= py[i];
-      pz[nx]=- pz[i];
+      pz[nx] = - pz[i];
       t1x[nx]= t1x[i];
       t1y[nx]= t1y[i];
-      t1z[nx]=- t1z[i];
+      t1z[nx] = - t1z[i];
       t2x[nx]= t2x[i];
       t2y[nx]= t2y[i];
-      t2z[nx]=- t2z[i];
-      psalp[nx]=- psalp[i];
+      t2z[nx] = - t2z[i];
+      psalp[nx] = - psalp[i];
       pbi[nx]= pbi[i];
     }
   
@@ -1187,10 +1187,10 @@ void c_geometry::reflect( int ix, int iy, int iz, int itx, int nop ) {
         }
       
         x[nx]= x[i];
-        y[nx]=- e1;
+        y[nx] = - e1;
         z[nx]= z[i];
         x2[nx]= x2[i];
-        y2[nx]=- e2;
+        y2[nx] = - e2;
         z2[nx]= z2[i];
         itagi= segment_tags[i];
       
@@ -1231,15 +1231,15 @@ void c_geometry::reflect( int ix, int iy, int iz, int itx, int nop ) {
         }
       
         px[nx]= px[i];
-        py[nx]=- py[i];
+        py[nx] = - py[i];
         pz[nx]= pz[i];
         t1x[nx]= t1x[i];
-        t1y[nx]=- t1y[i];
+        t1y[nx] = - t1y[i];
         t1z[nx]= t1z[i];
         t2x[nx]= t2x[i];
-        t2y[nx]=- t2y[i];
+        t2y[nx] = - t2y[i];
         t2z[nx]= t2z[i];
-        psalp[nx]=- psalp[i];
+        psalp[nx] = - psalp[i];
         pbi[nx]= pbi[i];
       } /* for( i = m2; i <= m; i++ ) */
     
@@ -1280,10 +1280,10 @@ void c_geometry::reflect( int ix, int iy, int iz, int itx, int nop ) {
           throw nex;
         }
       
-        x[nx]=- e1;
+        x[nx] = - e1;
         y[nx]= y[i];
         z[nx]= z[i];
-        x2[nx]=- e2;
+        x2[nx] = - e2;
         y2[nx]= y2[i];
         z2[nx]= z2[i];
         itagi= segment_tags[i];
@@ -1326,16 +1326,16 @@ void c_geometry::reflect( int ix, int iy, int iz, int itx, int nop ) {
         throw nex;
       }
     
-      px[nx]=- px[i];
+      px[nx] = - px[i];
       py[nx]= py[i];
       pz[nx]= pz[i];
-      t1x[nx]=- t1x[i];
+      t1x[nx] = - t1x[i];
       t1y[nx]= t1y[i];
       t1z[nx]= t1z[i];
-      t2x[nx]=- t2x[i];
+      t2x[nx] = - t2x[i];
       t2y[nx]= t2y[i];
       t2z[nx]= t2z[i];
-      psalp[nx]=- psalp[i];
+      psalp[nx] = - psalp[i];
       pbi[nx]= pbi[i];
     }
   
@@ -1345,7 +1345,7 @@ void c_geometry::reflect( int ix, int iy, int iz, int itx, int nop ) {
   
   /* reproduce structure with rotation to form cylindrical structure */
   fnop= (nec_float)nop;
-  m_ipsym=-1;
+  m_ipsym = -1;
   sam=two_pi() / fnop;
   cs= cos( sam);
   ss= sin( sam);
@@ -1778,7 +1778,7 @@ void c_geometry::connect_segments( int ignd )
         for (int i = 0; i < ic; i++ ) {
           ix= jco[i];
           if ( ix <= 0) {
-            ix=- ix;
+            ix = - ix;
             int ixx = ix-1; // TODO if ix == 0 we have a problem
             x[ixx]= xa;
             y[ixx]= ya;
@@ -2112,7 +2112,7 @@ void c_geometry::patch( int nx, int ny,
   
     if ( xa >= 1.0e-6)
     {
-      t1x[mi]=- ynv/ xa;
+      t1x[mi] = - ynv/ xa;
       t1y[mi]= xnv/ xa;
       t1z[mi]=0.;
     }
@@ -2567,11 +2567,11 @@ void c_geometry::tbf( int i, int icap )
     if ( jcox != 0 )
     {
       if ( jcox < 0 )
-        jcox=- jcox;
+        jcox = - jcox;
       else
       {
         _sig = -_sig;
-        jend=- jend;
+        jend = - jend;
       }
     
       jcoxx = jcox-1;
@@ -2595,7 +2595,7 @@ void c_geometry::tbf( int i, int icap )
       pp= pp- omc/ sd* aj;
       ax[jsnox]= aj/ sd* _sig;
       bx[jsnox]= aj/(2.* cdh);
-      cx[jsnox]=- aj/(2.* sdh)* _sig;
+      cx[jsnox] = - aj/(2.* sdh)* _sig;
     
       if ( jcox != i)
       {
@@ -2617,13 +2617,13 @@ void c_geometry::tbf( int i, int icap )
         }
       } /* if ( jcox != i) */
       else
-      bx[jsnox] =- bx[jsnox];
+      bx[jsnox] = - bx[jsnox];
     
       if ( iend == 1)
         break;
     } /* if ( jcox != 0 ) */
   
-    pm=- pp;
+    pm = - pp;
     pp=0.;
     njun1= jsno;
   
@@ -2633,7 +2633,7 @@ void c_geometry::tbf( int i, int icap )
   
     jend=1;
     iend=1;
-    _sig=-1.;
+    _sig = -1.;
   
   } /* do */
   while( jcox != 0 );
@@ -2676,7 +2676,7 @@ void c_geometry::tbf( int i, int icap )
     
       cx[jsnop]=1./( cdh- xxi* sdh);
       jsno= jsnop+1;
-      ax[jsnop]=-1.;
+      ax[jsnop] = -1.;
       return;
     } /* if ( njun2 == 0) */
   
@@ -2689,20 +2689,20 @@ void c_geometry::tbf( int i, int icap )
       xxi= qp*(1.-.5* xxi)/(1.- xxi);
     }
   
-    qp=-( omc+ xxi* sd)/( sd*( ap+ xxi* pp)+ cd*( xxi* ap- pp));
+    qp = -( omc+ xxi* sd)/( sd*( ap+ xxi* pp)+ cd*( xxi* ap- pp));
     d= cd- xxi* sd;
     bx[jsnop]=( sdh+ ap* qp*( cdh- xxi* sdh))/ d;
     cx[jsnop]=( cdh+ ap* qp*( sdh+ xxi* cdh))/ d;
   
     for( iend = 0; iend < njun2; iend++ )
     {
-      ax[iend]=-ax[iend]* qp;
+      ax[iend] = -ax[iend]* qp;
       bx[iend]= bx[iend]* qp;
-      cx[iend]=- cx[iend]* qp;
+      cx[iend] = - cx[iend]* qp;
     }
   
     jsno= jsnop+1;
-    ax[jsnop]=-1.;
+    ax[jsnop] = -1.;
     return;
   } /* if ( njun1 == 0) */
   
@@ -2730,14 +2730,14 @@ void c_geometry::tbf( int i, int icap )
     }
   
     jsno= jsnop+1;
-    ax[jsnop]=-1.;
+    ax[jsnop] = -1.;
     return;
   
   } /* if ( njun2 == 0) */
   
   qp= sd*( pm* pp+ aj* ap)+ cd*( pm* ap- pp* aj);
   qm=( ap* omc- pp* sd)/ qp;
-  qp=-( aj* omc+ pm* sd)/ qp;
+  qp = -( aj* omc+ pm* sd)/ qp;
   bx[jsnop]=( aj* qm+ ap* qp)* sdh/ sd;
   cx[jsnop]=( aj* qm- ap* qp)* cdh/ sd;
   
@@ -2751,13 +2751,13 @@ void c_geometry::tbf( int i, int icap )
   jend= njun1;
   for( iend = jend; iend < jsno; iend++ )
   {
-    ax[iend]=- ax[iend]* qp;
+    ax[iend] = - ax[iend]* qp;
     bx[iend]= bx[iend]* qp;
-    cx[iend]=- cx[iend]* qp;
+    cx[iend] = - cx[iend]* qp;
   }
   
   jsno= jsnop+1;
-  ax[jsnop]=-1.;
+  ax[jsnop] = -1.;
 }
 
 
@@ -2772,8 +2772,8 @@ void c_geometry::trio( int j )  {
   jcoxx = jcox-1;
   
   if ( jcox <= PCHCON)  {
-    jend=-1;
-    iend=-1;
+    jend = -1;
+    iend = -1;
   }
   
   if ( (jcox == 0) || (jcox > PCHCON) )  {
@@ -2806,9 +2806,9 @@ void c_geometry::trio( int j )  {
   
   do  {
     if ( jcox < 0 )
-      jcox=- jcox;
+      jcox = - jcox;
     else
-      jend=- jend;
+      jend = - jend;
     jcoxx = jcox-1;
   
     if ( jcox != j)  {
@@ -2902,18 +2902,18 @@ void c_geometry::sbf( int i, int is, nec_float *aa, nec_float *bb, nec_float *cc
     jcox= i;
   jcoxx = jcox-1;
   
-  jend=-1;
-  iend=-1;
-  sig=-1.;
+  jend = -1;
+  iend = -1;
+  sig = -1.;
   
   do  {
     // DEBUG_TRACE("c_geometry::sbf(" << i << "," << is << "): " << jcox);
     if ( jcox != 0 )  {
       if ( jcox < 0 )
-        jcox=- jcox;
+        jcox = - jcox;
       else  {
-        sig=- sig;
-        jend=- jend;
+        sig = - sig;
+        jend = - jend;
       }
     
       jcoxx = jcox-1;
@@ -2936,7 +2936,7 @@ void c_geometry::sbf( int i, int is, nec_float *aa, nec_float *bb, nec_float *cc
       if ( jcox == is)  {
         *aa= aj/ sd* sig;
         *bb= aj/(2.* cdh);
-        *cc=- aj/(2.* sdh)* sig;
+        *cc = - aj/(2.* sdh)* sig;
         june= iend;
       }
     
@@ -2958,13 +2958,13 @@ void c_geometry::sbf( int i, int is, nec_float *aa, nec_float *bb, nec_float *cc
       } /* if ( jcox != i ) */
       else
       if ( jcox == is)
-        *bb=- *bb;
+        *bb = - *bb;
     
       if ( iend == 1)
         break;
     } /* if ( jcox != 0 ) */
   
-    pm=- pp;
+    pm = - pp;
     pp=0.;
     njun1= local_jsno;
   
@@ -2974,7 +2974,7 @@ void c_geometry::sbf( int i, int is, nec_float *aa, nec_float *bb, nec_float *cc
   
     jend=1;
     iend=1;
-    sig=-1.;
+    sig = -1.;
   
   } /* do */
   while( jcox != 0 );
@@ -2998,7 +2998,7 @@ void c_geometry::sbf( int i, int is, nec_float *aa, nec_float *bb, nec_float *cc
   
   if ( njun1 == 0)  {
     if ( njun2 == 0)  {
-      *aa =-1.;
+      *aa = -1.;
       qp= pi()* segment_radius[ix];
       xxi= qp* qp;
       xxi= qp*(1.-.5* xxi)/(1.- xxi);
@@ -3009,12 +3009,12 @@ void c_geometry::sbf( int i, int is, nec_float *aa, nec_float *bb, nec_float *cc
     qp= pi()* segment_radius[ix];
     xxi= qp* qp;
     xxi= qp*(1.-.5* xxi)/(1.- xxi);
-    qp=-( omc+ xxi* sd)/( sd*( ap+ xxi* pp)+ cd*( xxi* ap- pp));
+    qp = -( omc+ xxi* sd)/( sd*( ap+ xxi* pp)+ cd*( xxi* ap- pp));
   
     if ( june == 1)  {
-      *aa=- *aa* qp;
+      *aa = - *aa* qp;
       *bb=  *bb* qp;
-      *cc=- *cc* qp;
+      *cc = - *cc* qp;
       if ( i != is)
         return;
     }
@@ -3050,7 +3050,7 @@ void c_geometry::sbf( int i, int is, nec_float *aa, nec_float *bb, nec_float *cc
   
   qp= sd*( pm* pp+ aj* ap)+ cd*( pm* ap- pp* aj);
   qm=( ap* omc- pp* sd)/ qp;
-  qp=-( aj* omc+ pm* sd)/ qp;
+  qp = -( aj* omc+ pm* sd)/ qp;
   
   if ( june != 0 )  {
     if ( june < 0 )  {
@@ -3058,9 +3058,9 @@ void c_geometry::sbf( int i, int is, nec_float *aa, nec_float *bb, nec_float *cc
       *bb= *bb* qm;
       *cc= *cc* qm;
     } else {
-      *aa=- *aa* qp;
+      *aa = - *aa* qp;
       *bb= *bb* qp;
-      *cc=- *cc* qp;
+      *cc = - *cc* qp;
     }
   
     if ( i != is)

--- a/src/c_ggrid.cpp
+++ b/src/c_ggrid.cpp
@@ -38,7 +38,7 @@ nec_float c_ggrid::m_ysa[3] = {0.,0.,.3490658504};
 void c_ggrid::interpolate( nec_float x, nec_float y, nec_complex *f1,
     nec_complex *f2, nec_complex *f3, nec_complex *f4 )
 {
-  static int ix, iy, ixs=-10, iys=-10, igrs=-10, ixeg=0, iyeg=0;
+  static int ix, iy, ixs = -10, iys = -10, igrs = -10, ixeg=0, iyeg=0;
   static int nxm2, nym2, nxms, nyms, nd, ndp;
   static nec_float dx = 1., dy = 1., xs = 0., ys = 0., xz, yz;
   static nec_complex a[4][4], b[4][4], c[4][4], d[4][4];
@@ -95,7 +95,7 @@ void c_ggrid::interpolate( nec_float x, nec_float y, nec_complex *f1,
     ixs=(( ix-1)/3)*3+2;
     if( ixs < 2)
       ixs=2;
-    ixeg=-10000;
+    ixeg = -10000;
   
     if( ixs > nxm2) {
       ixs= nxm2;
@@ -105,7 +105,7 @@ void c_ggrid::interpolate( nec_float x, nec_float y, nec_complex *f1,
     iys=(( iy-1)/3)*3+2;
     if( iys < 2)
       iys=2;
-    iyeg=-10000;
+    iyeg = -10000;
   
     if( iys > nym2) {
       iys= nym2;
@@ -298,7 +298,7 @@ void c_ggrid::sommerfeld( nec_float epr, nec_float sig, nec_float wavelength )
   cl2 = -CONST4*(m_epscf-1.)/(m_epscf+1.);
   cl1 = cl2/(m_epscf+1.);
   ezv = m_epscf*cl1;
-  thet=-dth;
+  thet = -dth;
   int nth = m_nya[0];
   
   for (int ith = 0; ith < nth; ith++ ) {
@@ -313,7 +313,7 @@ void c_ggrid::sommerfeld( nec_float epr, nec_float sig, nec_float wavelength )
     } else {
       erv=0.;
       erh=cl2-.5*cl1;
-      eph=-erh;
+      eph = -erh;
     }
   
     m_ar1[0+ith*11+  0]=erv;
@@ -342,7 +342,7 @@ nec_complex  fbar(const nec_complex& p )  {
     pow= z;
   
     for (int i = 1; i <= 100; i++ ) {
-      pow=- pow* zs/ (nec_float)i;
+      pow = - pow* zs/ (nec_float)i;
       term= pow/(2.* i+1.);
       sum = sum + term;
       tms = norm(term);
@@ -360,7 +360,7 @@ nec_complex  fbar(const nec_complex& p )  {
   /* asymptotic expansion */
   if ( real( z) < 0.) {
     minus=1;
-    z=- z;
+    z = - z;
   }
   else
     minus=0;
@@ -370,13 +370,13 @@ nec_complex  fbar(const nec_complex& p )  {
   term=cplx_10();
   
   for (int i = 1; i <= 6; i++ ) {
-    term =- term*(2.*i -1.)* zs;
+    term = - term*(2.*i -1.)* zs;
     sum += term;
   }
   
   if ( minus == 1)
     sum -= 2.0 * sqrt_pi() * z* exp( z* z);
-  fbar=- sum;
+  fbar = - sum;
   
   return( fbar );
 }
@@ -414,8 +414,8 @@ void gwave(nec_complex& erv, nec_complex& ezv,
     cpp2=1.0e-20;
   
   cpp= sqrt( cpp2);
-  rk1=- two_pi_j()* ground_wave.r1;
-  rk2=- two_pi_j()* ground_wave.r2;
+  rk1 = - two_pi_j()* ground_wave.r1;
+  rk2 = - two_pi_j()* ground_wave.r2;
   t1=1. -ground_wave.u2* cpp2;
   t2= sqrt( t1);
   t3=(1. -1./ rk1)/ rk1;
@@ -448,9 +448,9 @@ void gwave(nec_complex& erv, nec_complex& ezv,
   x5=3.* sppp* cppp* t3* xr1;
   x6= cpp* ground_wave.u* t2* omr* xr2/ rk2*.5;
   x7=3.* spp* cpp* t4* xr2;
-  erv=-( x1+ x2- x3+ x4- x5+ x6- x7)* (-CONST4);
+  erv = -( x1+ x2- x3+ x4- x5+ x6- x7)* (-CONST4);
 
-  ezh=-( x1- x2+ x3- x4- x5- x6+ x7)* (-CONST4);
+  ezh = -( x1- x2+ x3- x4- x5- x6+ x7)* (-CONST4);
 
   x1= sppp2* xr1;
   x2= rv* spp2* xr2;
@@ -466,6 +466,6 @@ void gwave(nec_complex& erv, nec_complex& ezv,
   x4= t3* xr1;
   x5= t4*(1.- ground_wave.u2*(1.+ rv)- ground_wave.u2* omr* f)* xr2;
   x6=.5* ground_wave.u2* omr*( f*( ground_wave.u2* t1- spp2-1./ rk2)+1./ rk2)* xr2/ rk2;
-  eph=-( x1- x2+ x3- x4+ x5+ x6)* (-CONST4);
+  eph = -( x1- x2+ x3- x4+ x5+ x6)* (-CONST4);
 }
 

--- a/src/matrix_algebra_tb.cpp
+++ b/src/matrix_algebra_tb.cpp
@@ -19,7 +19,7 @@ void matrix_setup(complex_array& A) {
   int n = 4;
   A(0,0) = 3.0;
   A(0,1) =1.0;
-  A(0,2) =-4.0;
+  A(0,2) = -4.0;
   A(0,3) =2.0;
   
   A(1,0) =3.0;
@@ -29,12 +29,12 @@ void matrix_setup(complex_array& A) {
   
   A(2,0) =2.0;
   A(2,1) =13.0;
-  A(2,2) =-1.0;
+  A(2,2) = -1.0;
   A(2,3) =0.0;
   
-  A(3,0) =-2.0;
+  A(3,0) = -2.0;
   A(3,1) =3.0;
-  A(3,2) =-1.0;
+  A(3,2) = -1.0;
   A(3,3) =4.0;
   for (int i = 1; i < n; i++ )  {
     for (int j = 0; j < i; j++ )
@@ -135,7 +135,7 @@ TEST_CASE( "LU Decomposition EIGEN", "[lu_decompose]") {
 
   A(0,0) = 3.0;
   A(0,1) =1.0;
-  A(0,2) =-4.0;
+  A(0,2) = -4.0;
   A(0,3) =2.0;
   
   A(1,0) =3.0;
@@ -145,12 +145,12 @@ TEST_CASE( "LU Decomposition EIGEN", "[lu_decompose]") {
   
   A(2,0) =2.0;
   A(2,1) =13.0;
-  A(2,2) =-1.0;
+  A(2,2) = -1.0;
   A(2,3) =0.0;
   
-  A(3,0) =-2.0;
+  A(3,0) = -2.0;
   A(3,1) =3.0;
-  A(3,2) =-1.0;
+  A(3,2) = -1.0;
   A(3,3) =4.0;
 
   cout << "Here is the matrix A:" << endl << A << endl;

--- a/src/nec_context.cpp
+++ b/src/nec_context.cpp
@@ -122,15 +122,15 @@ void nec_context::calc_prepare()
   m_excitation_type = EXCITATION_VOLTAGE;
   nload=0;
   network_count=0;
-  m_near=-1;
-  ifar=-1;
+  m_near = -1;
+  ifar = -1;
   ncoup=0;
   icoup=0;
   freq_mhz= em::speed_of_light() / 1.0e6;
   ground.default_values();
   nfrq=1;
-  iptflg=-2;
-  iptflq=-1;
+  iptflg = -2;
+  iptflq = -1;
   iped=0;
 }
 
@@ -842,7 +842,7 @@ void nec_context::pt_card(int itmp1, int itmp2, int itmp3, int itmp4) {
   iptagt= itmp4;
 
   if ( (itmp3 == 0) && (iptflg != -1) )
-    iptflg=-2;
+    iptflg = -2;
   if ( itmp4 == 0)
     iptagt= iptagf;
     
@@ -857,7 +857,7 @@ void nec_context::pq_card(int itmp1, int itmp2, int itmp3, int itmp4) {
   iptaqt= itmp4;
 
   if ( (itmp3 == 0) && (iptflq != -1) )
-    iptflq=-2;
+    iptflq = -2;
   if ( itmp4 == 0)
     iptaqt= iptaqf;
 }
@@ -1077,7 +1077,7 @@ void nec_context::simulate(bool far_field_flag) {
       xpr2  = phiss;
   
       if ( mhz == nfrq)
-        ifar=-1;
+        ifar = -1;
   
       if ( nfrq == 1)
       {
@@ -1674,7 +1674,7 @@ enum excitation_return nec_context::excitation_loop(int in_freq_loop_state, int 
           nfpat();
 
         if ( mhz == nfrq)
-          m_near=-1;
+          m_near = -1;
 
         if ( nfrq == 1)
         {
@@ -1724,7 +1724,7 @@ enum excitation_return nec_context::excitation_loop(int in_freq_loop_state, int 
     if ( (m_excitation_type == 0) || (m_excitation_type >= 4) )
     {
       if ( mhz == nfrq )
-        ifar=-1;
+        ifar = -1;
 
       if ( nfrq != 1)
       {
@@ -2130,9 +2130,9 @@ void nec_context::compute_matrix_ss( int j1, int j2, int im1, int im2,
   i1=( im1+1)/2;
   i2=( im2+1)/2;
   icomp= i1*2-3;
-  ii1=-2;
+  ii1 = -2;
   if ( icomp+2 < im1)
-    ii1=-3;
+    ii1 = -3;
   
   /* loop over observation patches */
   il = -1;
@@ -2154,7 +2154,7 @@ void nec_context::compute_matrix_ss( int j1, int j2, int im1, int im2,
     zi= m_geometry->pz[il];
   
     /* loop over source patches */
-    jj1=-2;
+    jj1 = -2;
     for(int j = j1; j <= j2; j++ )
     {
       jl=j-1;
@@ -2174,10 +2174,10 @@ void nec_context::compute_matrix_ss( int j1, int j2, int im1, int im2,
     
       hintg( xi, yi, zi);
     
-      g11=-( t2xi* exk+ t2yi* eyk+ t2zi* ezk);
-      g12=-( t2xi* exs+ t2yi* eys+ t2zi* ezs);
-      g21=-( t1xi* exk+ t1yi* eyk+ t1zi* ezk);
-      g22=-( t1xi* exs+ t1yi* eys+ t1zi* ezs);
+      g11 = -( t2xi* exk+ t2yi* eyk+ t2zi* ezk);
+      g12 = -( t2xi* exs+ t2yi* eys+ t2zi* ezs);
+      g21 = -( t1xi* exk+ t1yi* eyk+ t1zi* ezk);
+      g22 = -( t1xi* exs+ t1yi* eys+ t1zi* ezs);
     
       if ( i == j )
       {
@@ -2235,7 +2235,7 @@ void nec_context::cmsw( int j1, int j2, int i1, int i2, complex_array& in_cm,
   if (itrp < 0)
     return;
 
-  int k=-1;
+  int k = -1;
   int icgo=0;
   
   /* observation loop */
@@ -2252,7 +2252,7 @@ void nec_context::cmsw( int j1, int j2, int i1, int i2, complex_array& in_cm,
     
     if ( m_geometry->icon1[i] >= PCHCON) {
       ipch= m_geometry->icon1[i]-PCHCON;
-      fsign=-1.;
+      fsign = -1.;
     }
     
     if ( m_geometry->icon2[i] >= PCHCON) {
@@ -2384,9 +2384,9 @@ void nec_context::cmws( int j, int i1, int i2, complex_array& in_cm,
       tz= m_geometry->t1z[js];
     } /* if ( (ik != 0) || (ipr == 0) ) */
 
-    etk=-( exk* tx+ eyk* ty+ ezk* tz)* m_geometry->psalp[js];
-    ets=-( exs* tx+ eys* ty+ ezs* tz)* m_geometry->psalp[js];
-    etc=-( exc* tx+ eyc* ty+ ezc* tz)* m_geometry->psalp[js];
+    etk = -( exk* tx+ eyk* ty+ ezk* tz)* m_geometry->psalp[js];
+    ets = -( exs* tx+ eys* ty+ ezs* tz)* m_geometry->psalp[js];
+    etc = -( exc* tx+ eyc* ty+ ezc* tz)* m_geometry->psalp[js];
 
     /* fill matrix elements.  element locations */
     /* determined by connection data. */
@@ -2516,7 +2516,7 @@ void nec_context::cmww( int j, int i1, int i2, complex_array& in_cm,
   } /* if ( m_use_exk == true) */
   
   /* observation loop */
-  int ipr=-1;
+  int ipr = -1;
   for( i = i1-1; i < i2; i++ ) {
     ipr++;
     xi= m_geometry->x[i];
@@ -2883,14 +2883,14 @@ void nec_context::efld( nec_float xi, nec_float yi, nec_float zi, nec_float ai, 
       }
       else
       {
-        px=- yij/ xymag;
+        px = - yij/ xymag;
         py= xij/ xymag;
         cth= zij/ rmag;
         zrsin= sqrt(1.0 - zratx*zratx*(1.0 - cth*cth) );
       } /* if ( xymag <= 1.0e-6) */
     
       refs=( cth- zratx* zrsin)/( cth+ zratx* zrsin);
-      refps=-( zratx* cth- zrsin)/( zratx* cth+ zrsin);
+      refps = -( zratx* cth- zrsin)/( zratx* cth+ zrsin);
       refps= refps- refs;
       epy= px* txk+ py* tyk;
       epx= px* epy;
@@ -2940,7 +2940,7 @@ void nec_context::efld( nec_float xi, nec_float yi, nec_float zi, nec_float ai, 
   
   /* displace observation point for thin wire approximation */
   zij= zi+ zj;
-  salpr=- salpj;
+  salpr = - salpj;
   rhox= sabj* zij- salpr* yij;
   rhoy= salpr* xij- cabj* zij;
   rhoz= cabj* yij- sabj* xij;
@@ -2953,7 +2953,7 @@ void nec_context::efld( nec_float xi, nec_float yi, nec_float zi, nec_float ai, 
   } else {
     rh= ai/ sqrt( rh);
     if ( rhoz < 0.0)
-      rh=- rh;
+      rh = - rh;
     xo= xi+ rh* rhox;
     yo= yi+ rh* rhoy;
     zo= zi+ rh* rhoz;
@@ -3036,7 +3036,7 @@ void nec_context::eksc( nec_float s, nec_float z, nec_float rh, nec_float xk, in
   nec_float ss = sin(shk);
   nec_float cs = cos(shk);
   nec_float z2a = sh - z;
-  nec_float z1a =-(sh + z);
+  nec_float z1a = -(sh + z);
   
   nec_complex gz1, gz2, gp1, gp2;
   gx( z1a, rh, xk, &gz1, &gp1);
@@ -3045,21 +3045,21 @@ void nec_context::eksc( nec_float s, nec_float z, nec_float rh, nec_float xk, in
   nec_complex gzp2 = gp2 * z2a;
   
   *in_ezs=  __const1*(( gz2- gz1)* cs* xk-( gzp2+ gzp1)* ss);
-  *in_ezc=- __const1*(( gz2+ gz1)* ss* xk+( gzp2- gzp1)* cs);
+  *in_ezc = - __const1*(( gz2+ gz1)* ss* xk+( gzp2- gzp1)* cs);
   *erk= __const1*( gp2- gp1)* rh;
   
   nec_float cint, sint;
   intx(-shk, shk, rhk, ij, &cint, &sint);
-  *in_ezk=- __const1*( gzp2- gzp1+ xk* xk* nec_complex( cint,- sint));
+  *in_ezk = - __const1*( gzp2- gzp1+ xk* xk* nec_complex( cint,- sint));
   
   if ( rh >= 1.0e-10)
   {
     gzp1 = gzp1 * z1a;
     gzp2 = gzp2 * z2a;
     
-    *ers =- __const1*(( gzp2+ gzp1+ gz2+ gz1)*
+    *ers = - __const1*(( gzp2+ gzp1+ gz2+ gz1)*
       ss-( z2a* gz2- z1a* gz1)* cs*xk)/ rh;
-    *erc =- __const1*(( gzp2- gzp1+ gz2- gz1)*
+    *erc = - __const1*(( gzp2- gzp1+ gz2- gz1)*
       cs+( z2a* gz2+ z1a* gz1)* ss*xk)/ rh;
     return;
   }
@@ -3111,7 +3111,7 @@ void nec_context::ekscx( nec_float bx, nec_float s, nec_float z,
   ss= sin( shk);
   cs= cos( shk);
   z2a= sh- z;
-  z1a=-( sh+ z);
+  z1a = -( sh+ z);
   a2= b* b;
   
   if ( inx1 != 2)
@@ -3139,16 +3139,16 @@ void nec_context::ekscx( nec_float bx, nec_float s, nec_float z,
   }
   
   *in_ezs= __const1*(( gz2- gz1)* cs* xk-( gzp2+ gzp1)* ss);
-  *in_ezc=- __const1*(( gz2+ gz1)* ss* xk+( gzp2- gzp1)* cs);
-  *ers=- __const1*(( z2a* grp2+ z1a* grp1+ gr2+ gr1)*ss
+  *in_ezc = - __const1*(( gz2+ gz1)* ss* xk+( gzp2- gzp1)* cs);
+  *ers = - __const1*(( z2a* grp2+ z1a* grp1+ gr2+ gr1)*ss
     -( z2a* gr2- z1a* gr1)* cs* xk);
-  *erc=- __const1*(( z2a* grp2- z1a* grp1+ gr2- gr1)*cs
+  *erc = - __const1*(( z2a* grp2- z1a* grp1+ gr2- gr1)*cs
     +( z2a* gr2+ z1a* gr1)* ss* xk);
   *erk= __const1*( grk2- grk1);
   intx(- shk, shk, rhk, ij, &cint, &sint);
   bk= b* xk;
   bk2= bk* bk*.25;
-  *in_ezk=- __const1*( gzp2- gzp1+ xk* xk*(1.- bk2)*
+  *in_ezk = - __const1*( gzp2- gzp1+ xk* xk*(1.- bk2)*
     nec_complex( cint,- sint)-bk2*( gzz2- gzz1));
 }
 
@@ -3209,10 +3209,10 @@ void nec_context::etmns( nec_float p1, nec_float p2, nec_float p3, nec_float p4,
     set= sin( p3);
     pxl= cth* cph* cet- sph* set;
     pyl= cth* sph* cet+ cph* set;
-    pzl=- sth* cet;
-    wx=- sth* cph;
-    wy=- sth* sph;
-    wz=- cth;
+    pzl = - sth* cet;
+    wx = - sth* cph;
+    wy = - sth* sph;
+    wz = - cth;
     qx= wy* pzl- wz* pyl;
     qy= wz* pxl- wx* pzl;
     qz= wx* pyl- wy* pxl;
@@ -3221,8 +3221,8 @@ void nec_context::etmns( nec_float p1, nec_float p2, nec_float p3, nec_float p4,
     {
       if (ground.type_perfect())
       {
-        rrv=-cplx_10();
-        rrh=-cplx_10();
+        rrv = -cplx_10();
+        rrh = -cplx_10();
       }
       else
       {
@@ -3230,7 +3230,7 @@ void nec_context::etmns( nec_float p1, nec_float p2, nec_float p3, nec_float p4,
         rrh= ground.zrati* cth;
         rrh=( rrh- rrv)/( rrh+ rrv);
         rrv= ground.zrati* rrv;
-        rrv=-( cth- rrv)/( cth+ rrv);
+        rrv = -( cth- rrv)/( cth+ rrv);
       }
     }
   
@@ -3240,7 +3240,7 @@ void nec_context::etmns( nec_float p1, nec_float p2, nec_float p3, nec_float p4,
       {
         for (int i = 0; i < n; i++ )
         {
-          nec_float arg=- two_pi() *( wx* m_geometry->x[i]+ wy* m_geometry->y[i]+ wz* m_geometry->z[i]);
+          nec_float arg = - two_pi() *( wx* m_geometry->x[i]+ wy* m_geometry->y[i]+ wz* m_geometry->z[i]);
           nec_complex e_amplitude(cos(arg), sin(arg));
           
           e[i] = -(pxl*m_geometry->cab[i]+ pyl*m_geometry->sab[i]+ pzl*m_geometry->salp[i]) * e_amplitude * incident_amplitude;
@@ -3251,11 +3251,11 @@ void nec_context::etmns( nec_float p1, nec_float p2, nec_float p3, nec_float p4,
           tt1=( pyl* cph- pxl* sph)*( rrh- rrv);
           nec_complex cx= rrv* pxl- tt1* sph;
           nec_complex cy= rrv* pyl+ tt1* cph;
-          nec_complex cz=- rrv* pzl;
+          nec_complex cz = - rrv* pzl;
         
           for (int i = 0; i < n; i++ )
           {
-            nec_float arg=- two_pi()*( wx* m_geometry->x[i]+ wy* m_geometry->y[i]- wz* m_geometry->z[i]);
+            nec_float arg = - two_pi()*( wx* m_geometry->x[i]+ wy* m_geometry->y[i]- wz* m_geometry->z[i]);
             nec_complex e_amplitude(cos(arg), sin(arg));
             e[i] -= ( cx* m_geometry->cab[i]+ cy* m_geometry->sab[i]+ cz* m_geometry->salp[i])* e_amplitude * incident_amplitude;
           }
@@ -3286,8 +3286,8 @@ void nec_context::etmns( nec_float p1, nec_float p2, nec_float p3, nec_float p4,
       if (ground.present())
       {
         tt1=( qy* cph- qx* sph)*( rrv- rrh);
-        nec_complex cx=-( rrh* qx- tt1* sph);
-        nec_complex cy=-( rrh* qy+ tt1* cph);
+        nec_complex cx = -( rrh* qx- tt1* sph);
+        nec_complex cy = -( rrh* qy+ tt1* cph);
         nec_complex cz= rrh* qz;
         
         int i= -1;
@@ -3310,9 +3310,9 @@ void nec_context::etmns( nec_float p1, nec_float p2, nec_float p3, nec_float p4,
     } /* if ( excite_type == EXCITATION_LINEAR) */
 
     /* incident plane wave, elliptic polarization. */
-    tt1=-(cplx_01())* p6;
+    tt1 = -(cplx_01())* p6;
     if ( excite_type == EXCITATION_CIRC_LEFT)
-      tt1=- tt1;
+      tt1 = - tt1;
   
     if ( n != 0)
     {
@@ -3322,7 +3322,7 @@ void nec_context::etmns( nec_float p1, nec_float p2, nec_float p3, nec_float p4,
     
       for (int i = 0; i < n; i++ )
       {
-        nec_float arg=- two_pi()*( wx* m_geometry->x[i]+ wy* m_geometry->y[i]+ wz* m_geometry->z[i]);
+        nec_float arg = - two_pi()*( wx* m_geometry->x[i]+ wy* m_geometry->y[i]+ wz* m_geometry->z[i]);
         nec_complex e_amplitude(cos(arg), sin(arg));
         e[i] = -(cx* m_geometry->cab[i] + cy* m_geometry->sab[i] + cz*m_geometry->salp[i])* e_amplitude * incident_amplitude;
       }
@@ -3333,11 +3333,11 @@ void nec_context::etmns( nec_float p1, nec_float p2, nec_float p3, nec_float p4,
         tt2=( cy* cph- cx* sph)*( rrh- rrv);
         nec_complex ccx= rrv* cx- tt2* sph;
         nec_complex ccy= rrv* cy+ tt2* cph;
-        nec_complex ccz=- rrv* cz;
+        nec_complex ccz = - rrv* cz;
       
         for (int i = 0; i < n; i++ )
         {
-          nec_float arg=- two_pi()*( wx* m_geometry->x[i]+ wy* m_geometry->y[i]- wz* m_geometry->z[i]);
+          nec_float arg = - two_pi()*( wx* m_geometry->x[i]+ wy* m_geometry->y[i]- wz* m_geometry->z[i]);
           nec_complex e_amplitude(cos(arg), sin(arg));
           e[i] -= (ccx* m_geometry->cab[i]+ ccy* m_geometry->sab[i]+ ccz* m_geometry->salp[i]) * e_amplitude * incident_amplitude;
         }
@@ -3373,8 +3373,8 @@ void nec_context::etmns( nec_float p1, nec_float p2, nec_float p3, nec_float p4,
     if (ground.present())
     {
       tt1=( cy* cph- cx* sph)*( rrv- rrh);
-      cx=-( rrh* cx- tt1* sph);
-      cy=-( rrh* cy+ tt1* cph);
+      cx = -( rrh* cx- tt1* sph);
+      cy = -( rrh* cy+ tt1* cph);
       cz= rrh* cz;
 
       int i= -1;
@@ -3597,7 +3597,7 @@ void nec_context::gxx( nec_float zz, nec_float rh, nec_float a, nec_float a2, ne
   if ( ira != 1)
   {
     *g3=( *g3+ *gzp)* rh;
-    *gzp=- zz* c1* gz;
+    *gzp = - zz* c1* gz;
   
     if ( rh <= 1.0e-10)
     {
@@ -3612,11 +3612,11 @@ void nec_context::gxx( nec_float zz, nec_float rh, nec_float a, nec_float a2, ne
   } /* if ( ira != 1) */
   
   t2=.5* a;
-  *g2=- t2* c1* gz;
+  *g2 = - t2* c1* gz;
   *g2p= t2* gz* c2/ r2;
   *g3= rh2* *g2p- a* gz* c1;
   *g2p= *g2p* zz;
-  *gzp=- zz* c1* gz;
+  *gzp = - zz* c1* gz;
 }
 
 /*-----------------------------------------------------------------------*/
@@ -3778,7 +3778,7 @@ void nec_context::hintg( nec_float xi, nec_float yi, nec_float zi )
   
   rx= xi- xj;
   ry= yi- yj;
-  rfl=-1.;
+  rfl = -1.;
   exk=cplx_00();
   eyk=cplx_00();
   ezk=cplx_00();
@@ -3788,7 +3788,7 @@ void nec_context::hintg( nec_float xi, nec_float yi, nec_float zi )
   
   for (int ground_loop = 1; ground_loop <= ground.ksymp; ground_loop++ )
   {
-    rfl=- rfl;
+    rfl = - rfl;
     rz = zi - zj*rfl;
     rsq = rx*rx + ry*ry + rz*rz;
   
@@ -3799,7 +3799,7 @@ void nec_context::hintg( nec_float xi, nec_float yi, nec_float zi )
     rk= two_pi() * r;
     cr= cos( rk);
     sr= sin( rk);
-    gam=-( nec_complex(cr,-sr)+rk*nec_complex(sr,cr) )/( four_pi()*rsq*r )* m_s;
+    gam = -( nec_complex(cr,-sr)+rk*nec_complex(sr,cr) )/( four_pi()*rsq*r )* m_s;
     exc= gam* rx;
     eyc= gam* ry;
     ezc= gam* rz;
@@ -3816,12 +3816,12 @@ void nec_context::hintg( nec_float xi, nec_float yi, nec_float zi )
     {
       if (  ground.type_perfect() ) //ground.iperf == 1)
       {
-        f1x=- f1x;
-        f1y=- f1y;
-        f1z=- f1z;
-        f2x=- f2x;
-        f2y=- f2y;
-        f2z=- f2z;
+        f1x = - f1x;
+        f1y = - f1y;
+        f1z = - f1z;
+        f2x = - f2x;
+        f2y = - f2y;
+        f2z = - f2z;
       }
       else
       {
@@ -3835,7 +3835,7 @@ void nec_context::hintg( nec_float xi, nec_float yi, nec_float zi )
         }
         else
         {
-          pxx=- ry/ xymag;
+          pxx = - ry/ xymag;
           pyy= rx/ xymag;
           cth= rz/ r;
           rrv= sqrt(1.0 - ground.get_zrati_sqr() *(1.0 - cth* cth));
@@ -3844,7 +3844,7 @@ void nec_context::hintg( nec_float xi, nec_float yi, nec_float zi )
         rrh= ground.zrati* cth;
         rrh=( rrh- rrv)/( rrh+ rrv);
         rrv= ground.zrati* rrv;
-        rrv=-( cth- rrv)/( cth+ rrv);
+        rrv = -( cth- rrv)/( cth+ rrv);
         
         gam=( f1x* pxx+ f1y* pyy)*( rrv- rrh);
         f1x= f1x* rrh+ gam* pxx;
@@ -3879,11 +3879,11 @@ void nec_context::hsfld( nec_float xi, nec_float yi, nec_float zi, nec_float ai 
   
   xij= xi- xj;
   yij= yi- yj;
-  rfl=-1.;
+  rfl = -1.;
   
   for (int ground_loop = 0; ground_loop < ground.ksymp; ground_loop++ )
   {
-    rfl=- rfl;
+    rfl = - rfl;
     salpr= salpj* rfl;
     zij= zi- rfl* zj;
     zp= xij* cabj+ yij* sabj+ zij* salpr;
@@ -3947,14 +3947,14 @@ void nec_context::hsfld( nec_float xi, nec_float yi, nec_float zi, nec_float ai 
         }
         else
         {
-          px=- yij/ xymag;
+          px = - yij/ xymag;
           py= xij/ xymag;
           cth= zij/ rmag;
           rrv= sqrt(1.- zratx* zratx*(1.- cth* cth));
         }
       
         rrh= zratx* cth;
-        rrh=-( rrh- rrv)/( rrh+ rrv);
+        rrh = -( rrh- rrv)/( rrh+ rrv);
         rrv= zratx* rrv;
         rrv=( cth- rrv)/( cth+ rrv);
         qy=( phx* px+ phy* py)*( rrv- rrh);
@@ -4021,8 +4021,8 @@ void nec_context::hsflx( nec_float s, nec_float rh, nec_float zpx,
     }
     else
     {
-      zp=- zpx;
-      hss=-1.;
+      zp = - zpx;
+      hss = -1.;
     }
   
     dh= 0.5* s;
@@ -4049,8 +4049,8 @@ void nec_context::hsflx( nec_float s, nec_float rh, nec_float zpx,
       t1= z1* ekr1/ r1;
       t2= z2a* ekr2/ r2;
       *hps=( cdk*( ekr2- ekr1)- cplx_01()* sdk*( t2+ t1))* hss;
-      *hpc=- sdk*( ekr2+ ekr1)- cplx_01()* cdk*( t2- t1);
-      cons=- cplx_01()/(2.0 * two_pi() * rh);
+      *hpc = - sdk*( ekr2+ ekr1)- cplx_01()* cdk*( t2- t1);
+      cons = - cplx_01()/(2.0 * two_pi() * rh);
       *hps= cons* *hps;
       *hpc= cons* *hpc;
       return;
@@ -4619,7 +4619,7 @@ void nec_context::netwk( complex_array& in_cm, int_array& in_ip,
           y12r=0.;
           y12i=1./( x11r[j]* sin( y22r));
           y11r= x12r[j];
-          y11i=- y12i* cos( y22r);
+          y11i = - y12i* cos( y22r);
           y22r= x22r[j];
           y22i= y11i+ x22i[j];
           y11i= y11i+ x12i[j];
@@ -4645,7 +4645,7 @@ void nec_context::netwk( complex_array& in_cm, int_array& in_ip,
         jump2 = false;
         if ( ! jump1 )
         {
-          isc1=-1;
+          isc1 = -1;
       
           for( i = 0; i < nteq; i++ )
           {
@@ -4700,7 +4700,7 @@ void nec_context::netwk( complex_array& in_cm, int_array& in_ip,
         jump2 = false;
         if ( ! jump1 )
         {
-          isc2=-1;
+          isc2 = -1;
       
           for( i = 0; i < nteq; i++ )
           {
@@ -5503,7 +5503,7 @@ void nec_context::qdsrc( int is, nec_complex v, complex_array& e )
     if (ipr > PCHCON)
       ind1=2;
     else if ( ipr < 0 ) {
-      ipr=- ipr;
+      ipr = - ipr;
       ipr--;
       if ( -m_geometry->icon1[ipr-1] != jp1 ) {
         ind1=2;
@@ -6198,7 +6198,7 @@ void nec_context::unere( nec_float xob, nec_float yob, nec_float zob, bool groun
   
   if ( ground_reflection)
   {
-    zr =- zr;
+    zr = - zr;
     t1zr = -t1zr;
     t2zr = -t2zr;
   }
@@ -6241,13 +6241,13 @@ void nec_context::unere( nec_float xob, nec_float yob, nec_float zob, bool groun
   // handle the ground_reflection
   if (  ground.type_perfect() ) // (ground.iperf == 1)
   {
-    exk=- exk;
-    eyk=- eyk;  
+    exk = - exk;
+    eyk = - eyk;  
     
-    ezk=- ezk;
-    exs=- exs;
-    eys=- eys;
-    ezs=- ezs;
+    ezk = - ezk;
+    exs = - exs;
+    eys = - eys;
+    ezs = - ezs;
     return;
   }
   
@@ -6261,7 +6261,7 @@ void nec_context::unere( nec_float xob, nec_float yob, nec_float zob, bool groun
   }
   else
   {
-    px=- ry/ xymag;
+    px = - ry/ xymag;
     py= rx/ xymag;
     cth= rz/ sqrt( xymag* xymag+ rz* rz);
     rrv= sqrt(1.0- ground.get_zrati_sqr() * (1.0 - cth*cth));
@@ -6270,7 +6270,7 @@ void nec_context::unere( nec_float xob, nec_float yob, nec_float zob, bool groun
   rrh= ground.zrati* cth;
   rrh=( rrh- rrv)/( rrh+ rrv);
   rrv= ground.zrati* rrv;
-  rrv=-( cth- rrv)/( cth+ rrv);
+  rrv = -( cth- rrv)/( cth+ rrv);
   
   edp=( exk* px+ eyk* py)*( rrh- rrv);
   exk= exk* rrv+ edp* px;
@@ -6499,7 +6499,7 @@ void nec_context::fblock( int nrow, int ncol, int imax, int ipsym ) {
       for(int j = 0; j < kk; j++ )  {
         nec_complex deter = symmetry_array[i+j*nop];
         symmetry_array[i+(j+kk)*nop] = deter;
-        symmetry_array[i+kk+(j+kk)*nop] =- deter;
+        symmetry_array[i+kk+(j+kk)*nop] = - deter;
         symmetry_array[i+kk+j*nop] = deter;
       }
     }
@@ -6542,10 +6542,10 @@ void nec_context::gfld(nec_float rho, nec_float phi, nec_float rz,
   
   /* computation of space and ground waves. */
   ground_wave.set_u(ground.zrati);
-  phx=- sin( phi);
+  phx = - sin( phi);
   phy= cos( phi);
   rx= rho* phy;
-  ry=- rho* phx;
+  ry = - rho* phx;
   cix=cplx_00();
   ciy=cplx_00();
   ciz=cplx_00();
@@ -6581,18 +6581,18 @@ void nec_context::gfld(nec_float rho, nec_float phi, nec_float rz,
     }
   
     el= pi()* m_geometry->segment_length[i];
-    rfl=-1.;
+    rfl = -1.;
   
     /* Integration of (current)*(phase factor) over segment and image for 
        constant, sine, and cosine current distributions */
     for( k = 0; k < 2; k++ )  {
-      rfl=- rfl;
+      rfl = - rfl;
       riz= rz- m_geometry->z[i]* rfl;
       rxyz= sqrt( rix* rix+ riy* riy+ riz* riz);
       rnx= rix/ rxyz;
       rny= riy/ rxyz;
       rnz= riz/ rxyz;
-      omega=-( rnx* dx+ rny* dy+ rnz* dz* rfl);
+      omega = -( rnx* dx+ rny* dy+ rnz* dz* rfl);
       sill= omega* el;
       top= el+ sill;
       bot= el- sill;
@@ -6653,8 +6653,8 @@ void nec_context::gfld(nec_float rho, nec_float phi, nec_float rz,
   rny= ry/ r;
   rnz= rz/ r;
   thx= rnz* phy;
-  thy=- rnz* phx;
-  thz=- rho/ r;
+  thy = - rnz* phx;
+  thz = - rho/ r;
   *eth= cix* thx+ ciy* thy+ ciz* thz;
   *epi= cix* phx+ ciy* phy;
   *erd= cix* rnx+ ciy* rny+ ciz* rnz;
@@ -6676,14 +6676,14 @@ void nec_context::ffld(nec_float thet, nec_float phi,
   nec_complex zrsin, rrv, rrh, rrv1, rrh1, rrv2, rrh2;
   nec_complex tix, tiy, tiz, ex, ey, ez;
   
-  phx=- sin( phi);
+  phx = - sin( phi);
   phy= cos( phi);
   roz= cos( thet);
   rozs= roz;
   thx= roz* phy;
-  thy=- roz* phx;
-  thz=- sin( thet);
-  rox=- thz* phy;
+  thy = - roz* phx;
+  thz = - sin( thet);
+  rox = - thz* phy;
   roy= thz* phx;
   
   jump = false;
@@ -6694,12 +6694,12 @@ void nec_context::ffld(nec_float thet, nec_float phi,
     if ( k != 0 )  {
       /* for perfect ground */
       if (ground.type_perfect()) {
-        rrv=-cplx_10();
-        rrh=-cplx_10();
+        rrv = -cplx_10();
+        rrh = -cplx_10();
       } else {
         /* for infinite planar ground */
         zrsin= sqrt(1.- ground.get_zrati_sqr() * thz* thz);
-        rrv=-( roz- ground.zrati * zrsin)/( roz+ ground.zrati* zrsin);
+        rrv = -( roz- ground.zrati * zrsin)/( roz+ ground.zrati* zrsin);
         rrh=( ground.zrati* roz- zrsin)/( ground.zrati* roz+ zrsin);
       }
     
@@ -6713,13 +6713,13 @@ void nec_context::ffld(nec_float thet, nec_float phi,
           nec_complex zrati2 = ground.get_zrati2(in_wavelength);
           
           zrsin = sqrt(1.-  zrati2 *  zrati2 * thz* thz);
-          rrv2 =-( roz-  zrati2* zrsin)/( roz+  zrati2* zrsin);
+          rrv2 = -( roz-  zrati2* zrsin)/( roz+  zrati2* zrsin);
           rrh2 =(  zrati2* roz- zrsin)/(  zrati2* roz+ zrsin);
           darg = -two_pi() * 2.0 * ground.get_ch(in_wavelength) * roz;
         }
       } /* if ( ifar > 1) */
     
-      roz=- roz;
+      roz = - roz;
       ccx= cix;
       ccy= ciy;
       ccz= ciz;
@@ -6731,7 +6731,7 @@ void nec_context::ffld(nec_float thet, nec_float phi,
   
     /* loop over structure segments */
     for( i = 0; i < m_geometry->n_segments; i++ )  {
-      omega=-( rox* m_geometry->cab[i]+ roy* m_geometry->sab[i]+ roz* m_geometry->salp[i]);
+      omega = -( rox* m_geometry->cab[i]+ roy* m_geometry->sab[i]+ roz* m_geometry->salp[i]);
       el= pi()* m_geometry->segment_length[i];
       sill= omega* el;
       top= el+ sill;
@@ -6892,7 +6892,7 @@ void nec_context::ffld(nec_float thet, nec_float phi,
       rrh= ground.zrati * roz;
       rrh=( rrh- rrv)/( rrh+ rrv);
       rrv= ground.zrati * rrv;
-      rrv=-( roz- rrv)/( roz+ rrv);
+      rrv = -( roz- rrv)/( roz+ rrv);
       
       *eth=( tempx* phx+ tempy* phy)*( rrh- rrv);
       tempx= tempx* rrv+ *eth* phx;

--- a/src/nec_ground.cpp
+++ b/src/nec_ground.cpp
@@ -189,7 +189,7 @@ void nec_ground::calculate_antenna_environment(c_ground_wave& ground_wave, nec_f
   nec_float wavelength = em::get_wavelength(freq_mhz * 1.0e6);
   
   if ( sig < 0.)
-    sig=- sig/(em::impedance_over_2pi()*wavelength);
+    sig = - sig/(em::impedance_over_2pi()*wavelength);
 
   _epsc = nec_complex( epsr, -sig*wavelength*em::impedance_over_2pi());
   zrati = 1.0/ sqrt( _epsc);

--- a/src/nec_radiation_pattern.cpp
+++ b/src/nec_radiation_pattern.cpp
@@ -241,7 +241,7 @@ void nec_radiation_pattern::analyze(nec_context* m_context)
   if ( m_range >= 1.0e-20)  {
     exrm=1./ m_range;
     exra= m_range/ _wavelength;
-    exra=-360.*( exra- floor( exra));
+    exra = -360.*( exra- floor( exra));
   }
   
   nec_float pint = 0.0;
@@ -306,7 +306,7 @@ void nec_radiation_pattern::analyze(nec_context* m_context)
           stilta= sin( tilta);
           tstor1= tstor1* stilta* stilta;
           tstor2= tstor2* stilta* cos( tilta);
-          emajr2=- tstor1+ tstor2+ ethm2;
+          emajr2 = - tstor1+ tstor2+ ethm2;
           eminr2= tstor1- tstor2+ ephm2;
           if ( eminr2 < 0.)
             eminr2=0.;

--- a/src/net_solve.cpp
+++ b/src/net_solve.cpp
@@ -267,15 +267,15 @@ void c_network::net_solve( complex_array& cm, nec_complex *cmb,
 					y12r=0.;
 					y12i=1./( x11r[j]* sin( y22r));
 					y11r= x12r[j];
-					y11i=- y12i* cos( y22r);
+					y11i = - y12i* cos( y22r);
 					y22r= x22r[j];
 					y22i= y11i+ x22i[j];
 					y11i= y11i+ x12i[j];
 				
 					if ( ntyp[j] != 2)
 					{
-						y12r=- y12r;
-						y12i=- y12i;
+						y12r = - y12r;
+						y12i = - y12i;
 					}
 				} /* if ( ntyp[j] <= 1) */
 		
@@ -293,7 +293,7 @@ void c_network::net_solve( complex_array& cm, nec_complex *cmb,
 				jump2 = false;
 				if ( ! jump1 )
 				{
-					isc1=-1;
+					isc1 = -1;
 			
 					for( i = 0; i < nteq; i++ )
 					{
@@ -348,7 +348,7 @@ void c_network::net_solve( complex_array& cm, nec_complex *cmb,
 				jump2 = false;
 				if ( ! jump1 )
 				{
-					isc2=-1;
+					isc2 = -1;
 			
 					for( i = 0; i < nteq; i++ )
 					{


### PR DESCRIPTION
These vestiges of FORTRAN are not acceptable for clang compiler

find . -name '_.c' -o -name '_.cpp' -exec sed -i.bak -E -e 's/ ?=-/ = -/g' {} \;
find . -name '*.bak' -delete
