### PR TITLE
Fix compilation on recent compilers

### DIFF
--- a/src/c_plot_card.h
+++ b/src/c_plot_card.h
@@ -50,6 +50,8 @@ public:
 	
 	virtual ~c_plot_card();
 	
+	c_plot_card& operator=(const c_plot_card&) = default;
+	
 	bool is_valid()	const;
 	
 	bool storing()	const;

--- a/src/math_util.h
+++ b/src/math_util.h
@@ -210,6 +210,8 @@ public:
     _v[2] = in_z;
   }
   
+  nec_3vector(const nec_3vector&) = default;
+  
   /**!\brief The Euclidian norm */
   inline nec_float norm() const {
     return ::norm(_v[0], _v[1], _v[2]);


### PR DESCRIPTION
Fixes errors I get when compiling with g++ 9.1.0 by re-adding the default copy-constructor and operator= method. As far as I can see this should not change behavior.

```
In file included from c_geometry.h:30,
                 from c_geometry.cpp:19:
nec_wire.h: In constructor ‘nec_wire::nec_wire(const nec_3vector&, const nec_3vector&, nec_float, int)’:
nec_wire.h:31:48: error: implicitly-declared ‘constexpr nec_3vector::nec_3vector(const nec_3vector&)’ is deprecated [-Werror=deprecated-copy]
   31 |   : x0(a), x1(b), radius(in_radius), _tag_id(id)
      |                                                ^
In file included from c_geometry.h:20,
                 from c_geometry.cpp:19:
math_util.h:227:23: note: because ‘nec_3vector’ has user-provided ‘nec_3vector& nec_3vector::operator=(const nec_3vector&)’
  227 |   inline nec_3vector& operator=(const nec_3vector& copy) {
      |                       ^~~~~~~~
In file included from c_geometry.h:30,
                 from c_geometry.cpp:19:
nec_wire.h:31:48: error: implicitly-declared ‘constexpr nec_3vector::nec_3vector(const nec_3vector&)’ is deprecated [-Werror=deprecated-copy]
   31 |   : x0(a), x1(b), radius(in_radius), _tag_id(id)
      |                                                ^
```

and

```
nec_context.cpp: In member function ‘void nec_context::pl_card(const char*, int, int, int, int)’:
nec_context.cpp:984:57: error: implicitly-declared ‘c_plot_card& c_plot_card::operator=(const c_plot_card&)’ is deprecated [-Werror=deprecated-copy]
  984 |   plot_card = c_plot_card(itmp1,itmp2,itmp3,itmp4, fname);
      |                                                         ^
In file included from nec_radiation_pattern.h:25,
                 from nec_context.h:28,
                 from nec_context.cpp:19:
c_plot_card.h:48:2: note: because ‘c_plot_card’ has user-provided ‘c_plot_card::c_plot_card(const c_plot_card&)’
   48 |  c_plot_card(const c_plot_card& p);
      |  ^~~~~~~~~~~
```