### PR TITLE
Full output to stdout if output filename is "-". 

### DIFF
--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -21,7 +21,7 @@ void usage(void)
       "usage: nec2++ [-i<input-file-name>] [-o<output-file-name>]"
       "\n       -g: print maximum gain to stdout."
       "\n       -b: Perform NEC++ Benchmark."
-      "\n       -s: print results to standard output."
+      "\n       -s: print result summary to standard output."
       "\n       -c: print results in comma-separated-value (CSV) format,"
       "\n           this options is used in conjunction with (-s) above."
       "\n       -h: print this usage information and exit."

--- a/src/nec2cpp.cpp
+++ b/src/nec2cpp.cpp
@@ -196,8 +196,8 @@ int nec_main( int argc, char **argv, nec_output_file& s_output )
 		usage();
 		exit(-1);
 	}
-	
-	bool results_to_stdout = false;
+
+	bool summary_to_stdout = false;
 	// allocate a new nec_context;
 	nec_context s_context;
 	
@@ -219,7 +219,7 @@ int nec_main( int argc, char **argv, nec_output_file& s_output )
 			break;
 
 		case 's': /* return output to stdout */
-			results_to_stdout = true;
+			summary_to_stdout = true;
 			break;
 
 		case 'c': /* use CSV result data */
@@ -280,7 +280,11 @@ int nec_main( int argc, char **argv, nec_output_file& s_output )
 	}
 	
 	/* open output file */
-	if ( (output_fp = fopen(output_filename.c_str(), "w")) == NULL )
+	if ( output_filename == "-" )
+	{
+		output_fp = stdout;
+	}
+	else if ( (output_fp = fopen(output_filename.c_str(), "w")) == NULL )
 	{
 		string mesg = "nec2++: "  + output_filename;
 		
@@ -534,7 +538,7 @@ int nec_main( int argc, char **argv, nec_output_file& s_output )
 				******************************************************/
 				s_context.all_jobs_completed();
 				// put in here for the moment...
- 				if (results_to_stdout)
+				if (summary_to_stdout)
 					s_context.write_results(cout);
 				
 				/* time the process */


### PR DESCRIPTION
The program's help message previously was like this:

```
usage: nec2++ [-i<input-file-name>] [-o<output-file-name>]
       -g: print maximum gain to stdout.
       -b: Perform NEC++ Benchmark.
       -s: print results to standard output.
       -c: print results in comma-separated-value (CSV) format,
           this options is used in conjunction with (-s) above.
       -h: print this usage information and exit.
       -v: print nec2++ version number and exit.
```

This fooled me into thinking I could get the simulation results via the `-s` command line switch. But what I actually got was a excerpt, one might call it a summary.

This actually threw me off. For some time, it was my impression that the program does considerably less calculation than what one has come to expect from a NEC2 implementation. Only after generating and reading a regular output file (accidentally), I realized that the output generated by `-s` is sorely incomplete.

And there was no defined way to have that output piped to `stdout`. To have this is very convenient in a scripting environment.

This pull request addresses that problem, in two ways:

* The usage message is corrected to more clearly indicate that `-s` produces reduced output.
* When providing `-o -` as the output file, the full output is produced on `stdout` instead of a file.