### PR TITLE
Fix build under MS Visual Studio 2019

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -36,7 +36,7 @@ typedef std::complex<nec_float> nec_complex;
   #define nec_build_date BUILD_DATE
 #endif
 
-#ifdef WIN32
+#if defined(WIN32) || defined(_WIN32)
 #include "../win32/nec2++/config.h"
 #else
 #include "config.h"


### PR DESCRIPTION
cl.exe of MS Visual Studio 2019 defines _WIN32, not WIN32. This patch makes common.h check for either define.