### PR TITLE
Fix #87: Prevent false intersection errors for connected wires

### DIFF
--- a/src/c_geometry.cpp
+++ b/src/c_geometry.cpp
@@ -725,7 +725,17 @@ void c_geometry::wire( int tag_id, int segment_count, nec_float xw1, nec_float y
   for (uint32_t i=0; i<m_wires.size(); i++)
   {
     nec_wire a = m_wires[i];
-    if (a.intersect(seg_midpoint))
+    nec_3vector a_start = a.parametrize(0.0);
+    nec_3vector a_end = a.parametrize(1.0);
+
+    // Skip midpoint check if the new wire shares an endpoint with
+    // the existing wire — that's a connection, not an intersection.
+    bool shares_start = (a.distance(wire_start, a_start) < a.get_radius()) ||
+                        (a.distance(wire_start, a_end) < a.get_radius());
+    bool shares_end   = (a.distance(wire_end, a_start) < a.get_radius()) ||
+                        (a.distance(wire_end, a_end) < a.get_radius());
+
+    if (!shares_start && a.intersect(seg_midpoint))
     {
       nec_exception* nex = new nec_exception("GEOMETRY DATA ERROR -- FIRST SEGMENT MIDPOINT");
       nex->append(" OF WIRE #");
@@ -737,7 +747,7 @@ void c_geometry::wire( int tag_id, int segment_count, nec_float xw1, nec_float y
       
       throw nex;
     }
-    if (a.intersect(end_seg_midpoint))
+    if (!shares_end && a.intersect(end_seg_midpoint))
     {
       nec_exception* nex = new nec_exception("GEOMETRY DATA ERROR -- LAST SEGMENT MIDPOINT");
       nex->append(" OF WIRE #");

--- a/src/nec_wire.h
+++ b/src/nec_wire.h
@@ -54,6 +54,11 @@ public:
 		return _tag_id;
 	}
 
+	nec_float get_radius() const
+	{
+		return radius;
+	}
+
 /*!\brief Calculate whether two wires intersect.
 \return A list of the wires that should be created.
 */


### PR DESCRIPTION
When a new wire shares an endpoint with an existing wire, the midpoint
of the first (or last) segment falls within the existing wire's radius,
triggering a false "segment midpoint intersects" error.  Add a check
to skip the intersection test when the new wire's endpoint coincides
with the existing wire's endpoint (within its radius).

Also add nec_wire::get_radius() accessor.

Closes #87
