### PR TITLE
Fix #77: correct typos in K5332187.nec test data

### DIFF
--- a/testharness/data/K5332187.nec
+++ b/testharness/data/K5332187.nec
@@ -1,4 +1,4 @@
-CM *** Richtanzenne K 5332187 ***
+CM *** Richtantenne K 5332187 ***
 CM *** 87.5 - 108 MHz ***
 CM *** GW 1 = vertikal   GW 2 , 3 = horizontal ***
 CE
@@ -14,6 +14,6 @@ EX 0,0,06,00,10.,0
 EX 0,0,27,00,10.,0
 LD 5,0,0,0,3.72E+07
 PT -1
-'PL 3,1,0,3
+PL 3,1,0,3
 RP 0,361,2,1000,0.,0.,1.,90.
 EN


### PR DESCRIPTION
Closes #77

- Removed erroneous apostrophe before PL card (`'PL` → `PL`)
- Fixed comment typo `Richtanzenne` → `Richtantenne`