### PR TITLE
Fix #76, #75: Add LAPACKE support with --with-lapack configure option

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -104,8 +104,33 @@ LIBEIGENV=
 
 AC_CHECK_LIB([m],[pow])
 
+dnl ************************************************
+dnl *** Check for LAPACK
+dnl ************************************************
+
+AC_ARG_WITH([lapack],
+  [AS_HELP_STRING([--with-lapack],
+  [Enable LAPACK support for faster LU decomposition (requires LAPACKE)])],
+  [],
+  [with_lapack=no])
+
 EXPLICIT_LIBS=""
-PRIVATE_LIBS=" $LDFLAGS -lstdc++ -llapack -lblas -lpthread -lm"
+PRIVATE_LIBS=" $LDFLAGS -lstdc++ -lpthread -lm"
+
+AS_IF([test "x$with_lapack" != xno],
+[
+  AC_CHECK_HEADER(
+    [lapacke.h],
+    [AC_DEFINE([LAPACK], [1], [Define if LAPACKE is available])],
+    [AC_MSG_FAILURE([LAPACKE header not found (--without-lapack to disable)])],
+    [])
+  AC_CHECK_LIB([lapacke], [LAPACKE_zgetrf],
+    [],
+    [AC_MSG_FAILURE([LAPACKE library not found (--without-lapack to disable)])],
+    [-llapack -lblas])
+  PRIVATE_LIBS=" $LDFLAGS -lstdc++ -llapacke -llapack -lblas -lpthread -lm"
+  EXPLICIT_LIBS="-llapacke"
+])
 
 AC_SUBST(EXPLICIT_LIBS)
 AC_SUBST(PRIVATE_LIBS)

--- a/src/matrix_algebra.cpp
+++ b/src/matrix_algebra.cpp
@@ -405,10 +405,7 @@ void solve_ge( int64_t n, complex_array& a, int_array& ip,
 
 #if LAPACK
 
-extern "C"
-{
-#include <clapack.h>
-}
+#include <lapacke.h>
 
 
 
@@ -478,8 +475,8 @@ void lu_decompose_lapack(nec_output_file& s_output,    int64_t n, complex_array&
     *                                singular, and division by zero will occur if it is used
     *                                to solve a system of equations.
     */
-    int32_t info = clapack_zgetrf (CblasColMajor, int32_t(n), int32_t(n), 
-                    (void*) a_in.data(), int32_t(ndim), ip.data());
+    int32_t info = LAPACKE_zgetrf (LAPACK_COL_MAJOR, int32_t(n), int32_t(n), 
+                    reinterpret_cast<lapack_complex_double*>(a_in.data()), int32_t(ndim), ip.data());
     
     if (0 != info) {
         /*
@@ -510,8 +507,8 @@ void solve_lapack( int64_t n, complex_array& a, int_array& ip,
 {
     DEBUG_TRACE("solve_lapack(" << n << "," << ndim << ")");
 
-    int info = clapack_zgetrs (CblasColMajor, CblasNoTrans, 
-        static_cast<int>(n), 1, (void*) a.data(), static_cast<int>(ndim), ip.data(), b.data(), static_cast<int>(n));
+    int info = LAPACKE_zgetrs (LAPACK_COL_MAJOR, 'N', 
+        static_cast<int>(n), 1, reinterpret_cast<lapack_complex_double*>(a.data()), static_cast<int>(ndim), ip.data(), b.data(), static_cast<int>(n));
     
     if (0 != info) {
         /*


### PR DESCRIPTION
Closes #76, closes #75

## configure.ac
- Add `--with-lapack` / `--without-lapack` configure option
- Check for `lapacke.h` and `-llapacke` lib when enabled
- Define `LAPACK` preprocessor macro for conditional compilation
- Conditionally include lapacke/lapack/blas in pkg-config `PRIVATE_LIBS`
- When lapack is disabled, `PRIVATE_LIBS` no longer includes `-llapack -lblas` (fixes #76)

## matrix_algebra.cpp
- Replace Atlas-specific `clapack.h` with standard LAPACKE `lapacke.h`
- `clapack_zgetrf` → `LAPACKE_zgetrf` with `LAPACK_COL_MAJOR`
- `clapack_zgetrs` → `LAPACKE_zgetrs` with `'N'` transpose flag
- Use `reinterpret_cast<lapack_complex_double*>` for complex data