### PR TITLE
Fix #63, #48: Optional intersection check + helix validation

### DIFF
--- a/src/c_geometry.cpp
+++ b/src/c_geometry.cpp
@@ -42,6 +42,8 @@ c_geometry::c_geometry()
   nscon = 0;
   maxcon = 0;
   
+  _check_intersections = true;
+  
   m_context = NULL;
   m_output = NULL;
 }
@@ -490,6 +492,8 @@ void c_geometry::geometry_complete(nec_context* in_context, int gpflag)
     throw new nec_exception("Geometry has no wires or patches.");
     
   /* Check to see whether any wires intersect with one another */
+if (_check_intersections)
+{
   for (uint32_t i=0; i<m_wires.size(); i++)
   {
     nec_wire a = m_wires[i];
@@ -512,6 +516,7 @@ void c_geometry::geometry_complete(nec_context* in_context, int gpflag)
       }
     }
   }
+}
 
 // now proceed and complete the geometry setup...
   // Check here that patches form a closed surfaceAntennaInput
@@ -719,44 +724,47 @@ void c_geometry::wire( int tag_id, int segment_count, nec_float xw1, nec_float y
   nec_3vector wire_start(xw1,yw1,zw1);
   nec_3vector wire_end(xw2,yw2,zw2);
   
-  nec_3vector seg_midpoint(wire_start + (dx/2)*delz);
-  nec_3vector end_seg_midpoint = wire_end - (dx*delz / 2);
-  /* Check to see whether any wires intersect with the segment_midpoint */
-  for (uint32_t i=0; i<m_wires.size(); i++)
+  if (_check_intersections)
   {
-    nec_wire a = m_wires[i];
-    nec_3vector a_start = a.parametrize(0.0);
-    nec_3vector a_end = a.parametrize(1.0);
-
-    // Skip midpoint check if the new wire shares an endpoint with
-    // the existing wire — that's a connection, not an intersection.
-    bool shares_start = (a.distance(wire_start, a_start) < a.get_radius()) ||
-                        (a.distance(wire_start, a_end) < a.get_radius());
-    bool shares_end   = (a.distance(wire_end, a_start) < a.get_radius()) ||
-                        (a.distance(wire_end, a_end) < a.get_radius());
-
-    if (!shares_start && a.intersect(seg_midpoint))
+    nec_3vector seg_midpoint(wire_start + (dx/2)*delz);
+    nec_3vector end_seg_midpoint = wire_end - (dx*delz / 2);
+    /* Check to see whether any wires intersect with the segment_midpoint */
+    for (uint32_t i=0; i<m_wires.size(); i++)
     {
-      nec_exception* nex = new nec_exception("GEOMETRY DATA ERROR -- FIRST SEGMENT MIDPOINT");
-      nex->append(" OF WIRE #");
-      nex->append(m_wires.size()+1);
-      nex->append(" (TAG ID #"); nex->append(tag_id);
-      nex->append(") INTERSECTS WIRE #");
-      nex->append(i+1);
-      nex->append(" (TAG ID #"); nex->append(a.tag_id()); nex->append(")");
-      
-      throw nex;
-    }
-    if (!shares_end && a.intersect(end_seg_midpoint))
-    {
-      nec_exception* nex = new nec_exception("GEOMETRY DATA ERROR -- LAST SEGMENT MIDPOINT");
-      nex->append(" OF WIRE #");
-      nex->append(m_wires.size()+1);
-      nex->append(" (TAG ID #"); nex->append(tag_id);
-      nex->append(") INTERSECTS WIRE #");
-      nex->append(i+1);
-      nex->append(" (TAG ID #"); nex->append(a.tag_id()); nex->append(")");
-      throw nex;
+      nec_wire a = m_wires[i];
+      nec_3vector a_start = a.parametrize(0.0);
+      nec_3vector a_end = a.parametrize(1.0);
+
+      // Skip midpoint check if the new wire shares an endpoint with
+      // the existing wire — that's a connection, not an intersection.
+      bool shares_start = (a.distance(wire_start, a_start) < a.get_radius()) ||
+                          (a.distance(wire_start, a_end) < a.get_radius());
+      bool shares_end   = (a.distance(wire_end, a_start) < a.get_radius()) ||
+                          (a.distance(wire_end, a_end) < a.get_radius());
+
+      if (!shares_start && a.intersect(seg_midpoint))
+      {
+        nec_exception* nex = new nec_exception("GEOMETRY DATA ERROR -- FIRST SEGMENT MIDPOINT");
+        nex->append(" OF WIRE #");
+        nex->append(m_wires.size()+1);
+        nex->append(" (TAG ID #"); nex->append(tag_id);
+        nex->append(") INTERSECTS WIRE #");
+        nex->append(i+1);
+        nex->append(" (TAG ID #"); nex->append(a.tag_id()); nex->append(")");
+        
+        throw nex;
+      }
+      if (!shares_end && a.intersect(end_seg_midpoint))
+      {
+        nec_exception* nex = new nec_exception("GEOMETRY DATA ERROR -- LAST SEGMENT MIDPOINT");
+        nex->append(" OF WIRE #");
+        nex->append(m_wires.size()+1);
+        nex->append(" (TAG ID #"); nex->append(tag_id);
+        nex->append(") INTERSECTS WIRE #");
+        nex->append(i+1);
+        nex->append(" (TAG ID #"); nex->append(a.tag_id()); nex->append(")");
+        throw nex;
+      }
     }
   }
   
@@ -811,13 +819,14 @@ void c_geometry::helix(int tag_id, int segment_count, nec_float s, nec_float hl,
   nec_float zinc, sangle, hdia, turn, pitch, hmaj, hmin;
   
   ist= n_segments;
+  
+  if ( segment_count < 1)
+    throw new nec_exception("HELIX: segment count must be >= 1");
+
   n_segments += segment_count;
   np= n_segments;
   mp= m;
   m_ipsym=0;
-  
-  if ( segment_count < 1)
-    return;
   
   zinc= fabs( hl/ segment_count);
   

--- a/src/c_geometry.h
+++ b/src/c_geometry.h
@@ -126,10 +126,18 @@ public:
   
   void gx_card(int card_int_1, int card_int_2);
        
-  /*! \brief Geometry is complete
-   *  \exception nec_exception* If there is an error with the geometry.
-   */
-  void geometry_complete(nec_context* m_context, int gpflag);
+  	/*! \brief Enable or disable segment intersection checking.
+  	 *  Intersection checking is on by default. Disabling it can be useful
+  	 *  for geometries where closely-spaced parallel wires cause false
+  	 *  positive intersection errors (e.g., phasing stubs, boom models).
+  	 *  \param enable true to check (default), false to skip checks.
+  	 */
+  	void set_intersection_check(bool enable) { _check_intersections = enable; }
+
+  	/*! \brief Geometry is complete
+  	 *  \exception nec_exception* If there is an error with the geometry.
+  	 */
+  	void geometry_complete(nec_context* m_context, int gpflag);
   
   
   
@@ -207,10 +215,11 @@ private:
           nec_float *x2, nec_float *y2, nec_float *z2, 
           nec_float *rad );
 
-  nec_context* m_context;
-  nec_output_file* m_output;
+  	nec_context* m_context;
+  	nec_output_file* m_output;
+  	bool _check_intersections;
 
-  std::vector<nec_wire> m_wires;
+  	std::vector<nec_wire> m_wires;
   
   int patch_type;
   nec_3vector patch_x1, patch_x2, patch_x3, patch_x4;

--- a/src/nec_context_tb.cpp
+++ b/src/nec_context_tb.cpp
@@ -192,3 +192,33 @@ TEST_CASE( "Connected wires do not trigger false intersection", "[false_intersec
     geo->wire(2, 11, 0.0, 0.0, 0.5, 0.36, 0.36, 0.5, 0.002, 1.0, 1.0);
     REQUIRE_NOTHROW(nec.geometry_complete(0));
 }
+
+TEST_CASE( "Optional intersection check bypass", "[intersection_check]") {
+    // Regression test for #63: setting intersection check to false
+    // should allow geometries that would otherwise trigger errors.
+    nec_context nec;
+    nec.initialize();
+
+    c_geometry* geo = nec.get_geometry();
+    // Disable intersection checking
+    geo->set_intersection_check(false);
+
+    // Two overlapping parallel wires that would normally be rejected
+    // (same start point, same end point — definitely triggers intersection)
+    geo->wire(1, 5, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.001, 1.0, 1.0);
+    geo->wire(2, 5, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.001, 1.0, 1.0);
+    // Should succeed with intersection checking off
+    REQUIRE_NOTHROW(nec.geometry_complete(0));
+}
+
+TEST_CASE( "Helix rejects invalid segment_count", "[helix]") {
+    // Regression test for #48: helix with segment_count < 1 must throw
+    // rather than silently returning with no wires.
+    nec_context nec;
+    nec.initialize();
+
+    c_geometry* geo = nec.get_geometry();
+    REQUIRE_THROWS(geo->helix(1, 0, 0.1, 0.1, 0.01, 0.01, 0.01, 0.01, 0.001));
+    // Verify geometry has no segments from the failed helix
+    REQUIRE(geo->n_segments == 0);
+}


### PR DESCRIPTION
Closes #63, closes #48

## c_geometry
- Add `set_intersection_check(bool)` API to bypass O(n²) intersection checks for geometries with closely-spaced parallel wires (#63)
- Guard all intersection checks in `geometry_complete()` and `wire()` with the `_check_intersections` flag
- `helix()`: replace silent return with `nec_exception` throw when `segment_count < 1`, and move validation before state mutation (#48)

## Tests
- Add test for intersection check bypass (#63)
- Add test for helix rejecting invalid segment_count (#48)