### PR TITLE
Make Eigen the default, remove LAPACK option

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -13,7 +13,6 @@ dnl ************************************************
 dnl *** Check for Array Bounds
 dnl ************************************************
 
-
 AC_ARG_WITH([bounds],
   [AS_HELP_STRING([--with-bounds],
   [Enable support for bounds-checking])],
@@ -30,7 +29,6 @@ dnl ************************************************
 dnl *** Trigger typesafe integer checking
 dnl ************************************************
 
-
 AC_ARG_WITH([typecheck],
   [AS_HELP_STRING([--with-typecheck],
   [Enable support for typesafe integer checking])],
@@ -42,7 +40,6 @@ AS_IF([test "x$with_typecheck" = xyes],
   AC_SUBST([AM_CPPFLAGS], ["-DTYPESAFE_PEDANTIC=1"])
   AC_SUBST([CXXFLAGS], ["-g3 -O0 -DTYPESAFE_PEDANTIC=1"])
 ])
-
 
 dnl ************************************************
 dnl *** Add an automatic build date
@@ -59,99 +56,27 @@ else
 fi
 
 dnl ************************************************
-dnl *** Check for Eigen library
+dnl *** Check for Eigen (mandatory)
 dnl ************************************************
 
 AC_LANG([C++])
 AC_PROG_CXX
 LT_INIT
 
-
-AC_ARG_WITH([eigen],
-  [AS_HELP_STRING([--without-eigen],
-  [disable support for eigen])],
+CPPFLAGS="$CPPFLAGS -I/usr/include/eigen3"
+AC_CHECK_HEADER(
+  [Eigen/Dense],
   [],
-  [with_eigen=no])
+  [AC_MSG_FAILURE([Eigen library not found. Install libeigen3-dev.])],
+  [])
 
-AC_ARG_WITH([eigenv],
-  [AS_HELP_STRING([--without-eigenv],
-  [disable support for eigen])],
-  [],
-  [with_eigenv=no])
-
-LIBEIGEN=
-  AS_IF([test "x$with_eigen" != xno],
-  [
-    CPPFLAGS="$CPPFLAGS -I/usr/include/eigen3"
-    AC_CHECK_HEADER(
-    [Eigen/Core],
-    [AC_DEFINE([USING_EIGEN_ARRAY], [1], [Define if you have eigen])],
-    [AC_MSG_FAILURE([Eigen library test failed (--without-eigen to disable)])],
-    [])
-  ])
-
-LIBEIGENV=
-  AS_IF([test "x$with_eigenv" != xno],
-  [
-    CPPFLAGS="$CPPFLAGS -I/usr/include/eigen3"
-    AC_CHECK_HEADER(
-    [Eigen/Core],
-    [AC_DEFINE([USING_EIGEN_3VECT], [1], [Define if you have eigen])],
-    [AC_MSG_FAILURE([Eigen library test failed (--without-eigen to disable)])],
-    [])
-	  ])
-
-
-dnl ************************************************
-dnl *** Use Eigen for LU decomposition
-dnl ************************************************
-
-AC_ARG_WITH([eigen-lu],
-  [AS_HELP_STRING([--with-eigen-lu],
-  [Use Eigen PartialPivLU for LU decomposition instead of built-in Gauss elimination])],
-  [],
-  [with_eigen_lu=no])
-
-AS_IF([test "x$with_eigen_lu" != xno],
-[
-  CPPFLAGS="$CPPFLAGS -I/usr/include/eigen3"
-  AC_CHECK_HEADER(
-    [Eigen/Dense],
-    [AC_DEFINE([EIGEN_LU], [1], [Define if Eigen LU is used])],
-    [AC_MSG_FAILURE([Eigen library test failed (--without-eigen-lu to disable)])],
-    [])
-])
-
+dnl Eigen is now the default for all components.
+CPPFLAGS="$CPPFLAGS -DUSING_EIGEN_ARRAY=1 -DUSING_EIGEN_3VECT=1 -DEIGEN_LU=1"
 
 AC_CHECK_LIB([m],[pow])
 
-dnl ************************************************
-dnl *** Check for LAPACK
-dnl ************************************************
-
-AC_ARG_WITH([lapack],
-  [AS_HELP_STRING([--with-lapack],
-  [Enable LAPACK support for faster LU decomposition (requires LAPACKE)])],
-  [],
-  [with_lapack=no])
-
 EXPLICIT_LIBS=""
 PRIVATE_LIBS=" $LDFLAGS -lstdc++ -lpthread -lm"
-
-AS_IF([test "x$with_lapack" != xno],
-[
-  AC_CHECK_HEADER(
-    [lapacke.h],
-    [AC_DEFINE([LAPACK], [1], [Define if LAPACKE is available])],
-    [AC_MSG_FAILURE([LAPACKE header not found (--without-lapack to disable)])],
-    [])
-  AC_CHECK_LIB([lapacke], [LAPACKE_zgetrf],
-    [],
-    [AC_MSG_FAILURE([LAPACKE library not found (--without-lapack to disable)])],
-    [-llapack -lblas])
-  PRIVATE_LIBS=" $LDFLAGS -lstdc++ -llapacke -llapack -lblas -lpthread -lm"
-  EXPLICIT_LIBS="-llapacke"
-])
 
 AC_SUBST(EXPLICIT_LIBS)
 AC_SUBST(PRIVATE_LIBS)

--- a/src/math_util.h
+++ b/src/math_util.h
@@ -25,14 +25,11 @@
 #include "common.h"
 
 
-/*! \brief      Use the Eigen package for arrays 
-    \todo Work through how this should be done.
+/*! \brief      Use the Eigen package for arrays and vectors.
 */
-//#define USING_EIGEN_3VECT 1
 
-// Always use safe_array — it delegates to Eigen internally when
-// USING_EIGEN_ARRAY is defined at compile time.
 #include "safe_array.h"
+
 typedef safe_array<int32_t>    int_array;
 typedef safe_array<nec_float>  real_array;
 typedef safe_array<nec_complex> complex_array;
@@ -41,14 +38,13 @@ typedef safe_matrix<int32_t>    int_matrix;
 typedef safe_matrix<nec_float>  real_matrix;
 typedef safe_matrix<nec_complex> complex_matrix;
 
+/** \brief 3-vector backed by Eigen (SIMD-accelerated). */
+typedef Eigen::Matrix<nec_float,3,1>  nec_3vector;
+typedef Eigen::Matrix<nec_complex,3,1> nec_c3vector;
+
 inline void vector_fill(complex_array& x, int64_t start, int64_t N, const nec_complex& y) {
   x.fill(start, N, y);
 }
-
-
-// inline void vector_fill(complex_array& x, int64_t start, int64_t N, const nec_complex& y) {
-//   x.fill(start, N, y);
-// }
 
 
 inline nec_complex cplx_00() {
@@ -179,150 +175,6 @@ inline nec_float normL1(const nec_float x, const nec_float y, const nec_float z)
 
 
 
-
-#if USING_EIGEN_3VECT
-    #pragma GCC diagnostic push
-    #pragma GCC diagnostic ignored "-Wshadow"
-    #pragma GCC diagnostic ignored "-Wconversion"
-    #include <Eigen/Dense>
-    #pragma GCC diagnostic pop
-
-
-    typedef Eigen::Matrix<nec_float,3,1> nec_3vector;
-    typedef Eigen::Matrix<nec_complex,3,1> nec_c3vector;
-#else
-
-/** \brief A Class for handling 3 dimensional vectors */
-class nec_3vector
-{
-public:
-    
-  nec_3vector(const nec_float& in_x, const nec_float& in_y, const nec_float& in_z) {
-    _v[0] = in_x;
-    _v[1] = in_y;
-    _v[2] = in_z;
-  }
-  
-  nec_3vector(const nec_3vector&) = default;
-  
-  /**!\brief The Euclidian norm */
-  inline nec_float norm() const {
-    return ::norm(_v[0], _v[1], _v[2]);
-  }
-  
-  inline nec_float norm2() const {
-    return ::norm2(_v[0], _v[1], _v[2]);
-  }
-  
-  /**!\brief Squared norm (Eigen-compatible alias) */
-  inline nec_float squaredNorm() const {
-    return norm2();
-  }
-  
-  /**!\brief The L1-distance (often called the Manhattan norm) */
-  inline nec_float normL1() const {
-    return ::normL1(_v[0], _v[1], _v[2]);
-  }
-  
-  /**!\brief Cross product (Eigen-compatible alias) */
-  inline nec_3vector cross(const nec_3vector& a) const {
-    return (*this) * a;
-  }
-  
-  inline nec_3vector& operator=(const nec_3vector& copy) {
-    _v[0] = copy._v[0];
-    _v[1] = copy._v[1];
-    _v[2] = copy._v[2];
-    return *this;
-  }
-  
-  inline int operator==(const nec_3vector& copy) const {
-    if (_v[0] != copy._v[0])
-      return 0;
-    if (_v[1] != copy._v[1])
-      return 0;
-    if (_v[2] != copy._v[2])
-      return 0;
-
-    return 1;
-  }
-  
-  inline nec_3vector& operator+=(const nec_3vector& a) {
-    _v[0] += a._v[0];
-    _v[1] += a._v[1];
-    _v[2] += a._v[2];
-    return *this;
-  }
-  
-  inline nec_3vector operator+(nec_float a) const {
-    return nec_3vector(_v[0] + a, _v[1] + a, _v[2] + a);
-  }
-  
-  inline nec_3vector operator+(const nec_3vector& a) const {
-    return nec_3vector(_v[0] + a._v[0], _v[1] + a._v[1], _v[2] + a._v[2]);
-  }
-  
-  inline nec_3vector& operator-=(const nec_3vector& a) {
-    _v[0] -= a._v[0];
-    _v[1] -= a._v[1];
-    _v[2] -= a._v[2];
-    return *this;
-  }
-  
-  inline nec_3vector operator-(const nec_3vector& a) const {
-    return nec_3vector(_v[0] - a._v[0], _v[1] - a._v[1], _v[2] - a._v[2]);
-  }
-  
-  
-  inline nec_3vector& operator/=(const nec_float& a) {
-    _v[0] /= a;
-    _v[1] /= a;
-    _v[2] /= a;
-    return *this;
-  }
-  inline nec_3vector operator/(nec_float a) const {
-    return nec_3vector(_v[0] / a, _v[1] / a, _v[2] / a);
-  }
-  
-  inline nec_float dot(const nec_3vector& a) const {
-    return (_v[0] * a._v[0]) + (_v[1] * a._v[1]) + (_v[2] * a._v[2]);
-  }
-  
-  inline nec_3vector& operator*=(const nec_float& a) {
-    _v[0] *= a;
-    _v[1] *= a;
-    _v[2] *= a;
-    return *this;
-  }
-  inline nec_3vector operator*(nec_float a) const {
-    return nec_3vector(_v[0] * a, _v[1] * a, _v[2] * a);
-  }
-  
-  inline nec_float& operator()(int i) {
-    return _v[i];
-  }
-  
-  inline const nec_float& operator()(int i) const {
-    return _v[i];
-  }
-  
-  /**\brief Cross-product */
-  nec_3vector operator*(const nec_3vector& a) const {
-    return nec_3vector(
-      _v[1]*a._v[2] - _v[2]*a._v[1],
-      _v[2]*a._v[0] - _v[0]*a._v[2],
-      _v[0]*a._v[1] - _v[1]*a._v[0]);
-  }
-  
-  inline nec_float x() const	{ return _v[0]; }
-  inline nec_float y() const	{ return _v[1]; }
-  inline nec_float z() const	{ return _v[2]; }
-  
-  
-private:
-  nec_float _v[3];
-};
-#endif
 
 /**!\brief The Euclidian norm */
 inline nec_float norm(const nec_3vector& v) {

--- a/src/matrix_algebra.cpp
+++ b/src/matrix_algebra.cpp
@@ -403,130 +403,10 @@ void solve_ge( int64_t n, complex_array& a, int_array& ip,
 }
 
 
-#if LAPACK
-
-#include <lapacke.h>
-
-
-
-/*! \brief Use lapack to perform LU decomposition
-*/
-void lu_decompose_lapack(nec_output_file& s_output,    int64_t n, complex_array& a_in, int_array& ip, int64_t ndim)
-{
-    UNUSED(s_output);
-    DEBUG_TRACE("lu_decompose_lapack(" << n << "," << ndim << ")");
-    ASSERT(n <= ndim);
-
-#ifdef NEC_MATRIX_CHECK
-    cout << "atlas_a = ";
-    to_octave(a_in,n,ndim);
-#endif
-
-    /* Un-transpose the matrix for Gauss elimination */
-    for (int i = 1; i < n; i++ ) {
-        int64_t i_offset = i * ndim;
-        int64_t j_offset = 0;
-        for (int64_t j = 0; j < i; j++ ) {
-            nec_complex aij = a_in[i+j_offset];
-            a_in[i+j_offset] = a_in[j+i_offset];
-            a_in[j+i_offset] = aij;
-            
-            j_offset += ndim;
-        }
-    }
-    
-                    
-    /* Now call the LAPACK LU-Decomposition
-    ZGETRF computes an LU factorization of a general M-by-N matrix A
-    *    using partial pivoting with row interchanges.
-    *
-    *    The factorization has the form
-    *         A = P * L * U
-    *    where P is a permutation matrix, L is lower triangular with unit
-    *    diagonal elements (lower trapezoidal if m > n), and U is upper
-    *    triangular (upper trapezoidal if m < n).
-
-    Arguments
-    *    =========
-    *
-    *    M             (input) INTEGER
-    *                    The number of rows of the matrix A.    M >= 0.
-    *
-    *    N             (input) INTEGER
-    *                    The number of columns of the matrix A.    N >= 0.
-    *
-    *    A             (input/output) COMPLEX*16 array, dimension (LDA,N)
-    *                    On entry, the M-by-N matrix to be factored.
-    *                    On exit, the factors L and U from the factorization
-    *                    A = P*L*U; the unit diagonal elements of L are not stored.
-    *
-    *    LDA         (input) INTEGER
-    *                    The leading dimension of the array A.    LDA >= max(1,M).
-    *
-    *    IPIV        (output) INTEGER array, dimension (min(M,N))
-    *                    The pivot indices; for 1 <= i <= min(M,N), row i of the
-    *                    matrix was interchanged with row IPIV(i).
-    *
-    *    INFO        (output) INTEGER
-    *                    = 0:    successful exit
-    *                    < 0:    if INFO = -i, the i-th argument had an illegal value
-    *                    > 0:    if INFO = i, U(i,i) is exactly zero. The factorization
-    *                                has been completed, but the factor U is exactly
-    *                                singular, and division by zero will occur if it is used
-    *                                to solve a system of equations.
-    */
-    int32_t info = LAPACKE_zgetrf (LAPACK_COL_MAJOR, int32_t(n), int32_t(n), 
-                    reinterpret_cast<lapack_complex_double*>(a_in.data()), int32_t(ndim), ip.data());
-    
-    if (0 != info) {
-        /*
-            The factorization has been completed, but the factor U is exactly singular,
-            and division by zero will occur if it is used to solve a system of equations. 
-        */
-        throw new nec_exception("nec++:    LU Decomposition Failed: ",info);
-    }
-    
-    
-#ifdef NEC_MATRIX_CHECK
-    cout << "atlas_solved = ";
-    to_octave(a_in,n,ndim);
-
-    cout << "atlas_ip = ";
-    to_octave(ip,n);
-#endif
-} 
-
-/*! \brief Solve system of linear equations
-    Subroutine to solve the matrix equation lu*x=b where l is a unit
-    lower triangular matrix and u is an upper triangular matrix both
-    of which are stored in a.    the rhs vector b is input and the
-    solution is returned through vector b.     (matrix transposed)
-*/
-void solve_lapack( int64_t n, complex_array& a, int_array& ip,
-        complex_array& b, int64_t ndim )
-{
-    DEBUG_TRACE("solve_lapack(" << n << "," << ndim << ")");
-
-    int info = LAPACKE_zgetrs (LAPACK_COL_MAJOR, 'N', 
-        static_cast<int>(n), 1, reinterpret_cast<lapack_complex_double*>(a.data()), static_cast<int>(ndim), ip.data(), b.data(), static_cast<int>(n));
-    
-    if (0 != info) {
-        /*
-            The factorization has been completed, but the factor U is exactly singular,
-            and division by zero will occur if it is used to solve a system of equations. 
-        */
-        throw new nec_exception("nec++: Solving Failed: ",info);
-    }
-}
-
-#endif /*    LAPACK */
-
-#if EIGEN_LU
-
-#include <Eigen/Dense>
-
-
-void lu_decompose_eigen(nec_output_file& s_output,    int64_t n, complex_array& a_in, int_array& ip, int64_t ndim)
+/*! \brief Use Eigen PartialPivLU to perform LU decomposition.
+    The input matrix a_in is in NEC column-major transposed format.
+    On return, a_in contains L+U factors and ip contains 1-indexed pivots. */
+void lu_decompose_eigen(nec_output_file& s_output, int64_t n, complex_array& a_in, int_array& ip, int64_t ndim)
 {
     UNUSED(s_output);
     DEBUG_TRACE("lu_decompose_eigen(" << n << "," << ndim << ")");
@@ -545,7 +425,6 @@ void lu_decompose_eigen(nec_output_file& s_output,    int64_t n, complex_array& 
             nec_complex aij = a_in[i+j_offset];
             a_in[i+j_offset] = a_in[j+i_offset];
             a_in[j+i_offset] = aij;
-            
             j_offset += ndim;
         }
     }
@@ -558,15 +437,10 @@ void lu_decompose_eigen(nec_output_file& s_output,    int64_t n, complex_array& 
     
     Eigen::PartialPivLU<MatrixXcd> lu(A_map);
     
-    /* Copy LU factors back into a_in (modifies through the Map).
-       Eigen's matrixLU() returns the combined L+U matrix with the same
-       storage convention as NEC (lower = L with implicit unit diag,
-       upper = U with explicit diagonal). */
+    /* Copy LU factors back into a_in (modifies through the Map). */
     A_map = lu.matrixLU();
     
-    /* Copy pivots. Eigen uses 0-based indices in the same convention
-       as LAPACK's IPIV (row at position i came from position indices[i]),
-       while NEC uses 1-based indexing for ip[]. */
+    /* Copy pivots (0-based to 1-based). */
     auto indices = lu.permutationP().indices();
     for (int64_t i = 0; i < n; i++)
         ip[i] = static_cast<int32_t>(indices[i]) + 1;
@@ -574,7 +448,6 @@ void lu_decompose_eigen(nec_output_file& s_output,    int64_t n, complex_array& 
 #ifdef NEC_MATRIX_CHECK
     cout << "eigen_solved = ";
     to_octave(a_in,n,ndim);
-
     cout << "eigen_ip = ";
     to_octave(ip,n);
 #endif
@@ -582,35 +455,22 @@ void lu_decompose_eigen(nec_output_file& s_output,    int64_t n, complex_array& 
 
 
 /* solve_eigen delegates to solve_ge — the LU factors are stored
-   in the same L+U format regardless of which factorization was used. */
+   in the same L+U format regardless of factorization method. */
 void solve_eigen( int64_t n, complex_array& a, int_array& ip,
         complex_array& b, int64_t ndim )
 {
     solve_ge(n, a, ip, b, ndim);
 }
 
-#endif /* EIGEN_LU */
 
 void lu_decompose(nec_output_file& s_output, int64_t n, complex_array& a, int_array& ip, int64_t ndim)
 {
-#if LAPACK
-    return lu_decompose_lapack(s_output, n, a, ip, ndim);
-#elif EIGEN_LU
     return lu_decompose_eigen(s_output, n, a, ip, ndim);
-#else
-    return lu_decompose_ge(s_output, n, a, ip, ndim);
-#endif
 }
 
 void solve( int64_t n, complex_array& a, int_array& ip, complex_array& b, int64_t ndim )
 {
-#if LAPACK
-    return solve_lapack(n, a, ip, b, ndim);
-#elif EIGEN_LU
     return solve_eigen(n, a, ip, b, ndim);
-#else
-    return solve_ge(n, a, ip, b, ndim);
-#endif
 }
 
 /*-----------------------------------------------------------------------*/

--- a/src/matrix_algebra.h
+++ b/src/matrix_algebra.h
@@ -22,30 +22,17 @@
 #include "math_util.h"
 #include "nec_output.h"
 
-/** \brief LU that uses either lapack or built in
- * */
+/** \brief LU decomposition and solve using Eigen PartialPivLU. */
 void lu_decompose(nec_output_file& s_output, int64_t n, complex_array& a, int_array& ip, int64_t ndim);
 void solve( int64_t n, complex_array& a, int_array& ip, complex_array& b, int64_t ndim );
 
-/** \brief LU that uses built in functions (no library dependency)
- * */
+/** \brief Built-in Gauss-Doolittle LU (reference implementation). */
 void lu_decompose_ge(nec_output_file& s_output, int64_t n, complex_array& a, int_array& ip, int64_t ndim);
 void solve_ge( int64_t n, complex_array& a, int_array& ip, complex_array& b, int64_t ndim );
 
-#if LAPACK
-/** \brief LU that uses LAPACK. These are not built unless a LAPACK is chosen at
- * compile time.
- * */
-void lu_decompose_lapack(nec_output_file& s_output, int64_t n, complex_array& a, int_array& ip, int64_t ndim);
-void solve_lapack( int64_t n, complex_array& a, int_array& ip, complex_array& b, int64_t ndim );
-#endif
-
-#if EIGEN_LU
-/** \brief LU that uses Eigen's PartialPivLU.
- * */
+/** \brief Eigen PartialPivLU wrapper (used internally by lu_decompose). */
 void lu_decompose_eigen(nec_output_file& s_output, int64_t n, complex_array& a, int_array& ip, int64_t ndim);
 void solve_eigen( int64_t n, complex_array& a, int_array& ip, complex_array& b, int64_t ndim );
-#endif
 
 
 void factrs(nec_output_file& s_output,  int64_t np, int64_t nrow, complex_array& a, int_array& ip );

--- a/src/matrix_algebra_tb.cpp
+++ b/src/matrix_algebra_tb.cpp
@@ -85,7 +85,7 @@ TEST_CASE( "LU Decomposition Gauss-Doolittle", "[lu_decompose_ge]") {
 }
 
 
-TEST_CASE( "LU Decomposition LAPACK", "[lu_decompose]") {
+TEST_CASE( "LU Decomposition (Eigen)", "[lu_decompose]") {
     int N=4;
     nec_output_file s_output;
     complex_matrix A(N,N);
@@ -122,60 +122,28 @@ TEST_CASE( "LU Decomposition LAPACK", "[lu_decompose]") {
     REQUIRE_APPROX_EQUAL(A(3,3), 5.72973);
 }
 
-#if USING_EIGEN_3VECT
 
-#include <Eigen/Dense>
-using namespace Eigen;
-#include <iostream>
-using namespace std;
-
-TEST_CASE( "LU Decomposition EIGEN", "[lu_decompose]") {
-  
+TEST_CASE( "LU Decomposition (Eigen self-check)", "[lu_decompose]") {
+  using namespace Eigen;
   MatrixXcd A(4,4);
 
-  A(0,0) = 3.0;
-  A(0,1) =1.0;
-  A(0,2) = -4.0;
-  A(0,3) =2.0;
-  
-  A(1,0) =3.0;
-  A(1,1) =1.0;
-  A(1,2) =0.0;
-  A(1,3) =2.0;
-  
-  A(2,0) =2.0;
-  A(2,1) =13.0;
-  A(2,2) = -1.0;
-  A(2,3) =0.0;
-  
-  A(3,0) = -2.0;
-  A(3,1) =3.0;
-  A(3,2) = -1.0;
-  A(3,3) =4.0;
+  A(0,0) = 3.0;  A(0,1) = 1.0;  A(0,2) = -4.0;  A(0,3) = 2.0;
+  A(1,0) = 3.0;  A(1,1) = 1.0;  A(1,2) =  0.0;  A(1,3) = 2.0;
+  A(2,0) = 2.0;  A(2,1) =13.0;  A(2,2) = -1.0;  A(2,3) = 0.0;
+  A(3,0) =-2.0;  A(3,1) = 3.0;  A(3,2) = -1.0;  A(3,3) = 4.0;
 
-  cout << "Here is the matrix A:" << endl << A << endl;
-  
-  Eigen::PartialPivLU<MatrixXcd> lu(A);
-  cout << "Here is, up to permutations, its LU decomposition matrix:"
-  << endl << lu.matrixLU() << endl;
-  cout << "Here is the L part:" << endl;
+  PartialPivLU<MatrixXcd> lu(A);
   MatrixXcd l = MatrixXcd::Identity(4,4);
   l.triangularView<StrictlyLower>() = lu.matrixLU();
-  cout << l << endl;
-  cout << "Here is the U part:" << endl;
   MatrixXcd u = lu.matrixLU().triangularView<Upper>();
-  cout << u << endl;
-  cout << "Let us now reconstruct the original matrix m:" << endl;
   MatrixXcd B = lu.permutationP().inverse() * l * u;
-  cout << B << endl;
+
   for (int i=0;i<4;i++) {
     for (int j=0; j<4; j++) {
       REQUIRE_APPROX_EQUAL(B(i,j), A(i,j));
     }
   }
 }
-
-#endif /* #if USING_EIGEN_3VECT */
 
 /*-----------------------------------------------------------------------*/
 

--- a/src/safe_array.h
+++ b/src/safe_array.h
@@ -22,6 +22,7 @@
 #include <cstring>
 #include <sstream>
 #include <stdint.h>
+#include <Eigen/Dense>
 
 #include "nec_exception.h"
 
@@ -35,11 +36,6 @@ public:
     m_message << "array index: " << index << " exceeds " << bound << std::endl;
   }
 };
-
-
-#if USING_EIGEN_ARRAY
-
-#include <Eigen/Dense>
 
 /*! \brief A Safe Array class backed by Eigen for SIMD-accelerated operations.
  *
@@ -72,7 +68,7 @@ public:
     copy(in_array);
   }
 
-  ~safe_array() { /* Eigen::Matrix destructor handles cleanup of _storage */ }
+  ~safe_array() { /* Eigen::Matrix destructor handles cleanup */ }
 
   int64_t size() const    { return _len; }
   int64_t rows() const    { return _rows; }
@@ -99,7 +95,6 @@ public:
       throw new nec_exception("attempt to resize data we do not own");
 #endif
     if (new_length > _capacity) {
-      // geometric growth to avoid O(n²) reallocation
       _capacity = new_length * 2;
       try {
         Vector new_storage(_capacity);
@@ -162,15 +157,13 @@ public:
   }
 
   const T& operator[](int64_t i) const {
-    return (*this)[check(i)];  // calls non-const, returns const ref
+    return _own_data ? _storage(check(i)) : _view_ptr[check(i)];
   }
 
   T& operator[](int64_t i) {
     return _own_data ? _storage(check(i)) : _view_ptr[check(i)];
   }
 
-  /*! \brief Return a non-owning view of a subset of this array.
-      Modifications to the segment write through to the original data. */
   safe_array<T> segment(int64_t start_index, int64_t end_index) {
     if (int64_t(-1) == end_index)
       throw "foo";
@@ -212,7 +205,6 @@ protected:
   T*    _view_ptr;            // non-owning view pointer
   bool  _own_data;
 
-  /*! \brief Constructor used to construct segment views */
   safe_array(const safe_array<T>& in_array, int64_t start_index,
              int64_t end_index, bool in_copy_data)
   {
@@ -253,7 +245,6 @@ protected:
   }
 
 private:
-  /* Return an Eigen expression for the active data (view or owning) */
   Eigen::Map<Vector> _eigen_view() {
     return Eigen::Map<Vector>(data(), _len);
   }
@@ -275,307 +266,5 @@ public:
 private:
   using safe_array<T>::operator[];
 };
-
-#else /* !USING_EIGEN_ARRAY — original implementation */
-
-/*! \brief A Safe Array class for nec2++ that performs bounds checking 
- * 
- * Bounds checking is done if the macro NEC_ERROR_CHECK is defined at compile time.
- * 
- * This class also includes some utility functions for handling common vector operations.
- */
-template<typename T>
-class safe_array {
-public:
-  safe_array()
-    : _len(0), _rows(0), _cols(0), _resize_chunk(2), _data(NULL), _data_size(0), _own_data(true)
-  { }
-
-  safe_array(int64_t in_size)
-    : _len(0), _rows(0), _cols(0), _resize_chunk(2), _data(NULL), _data_size(0), _own_data(true)
-  {
-    resize(in_size);
-  }
-  
-  safe_array(const safe_array<T>& in_array)
-    : _len(0), _rows(0), _cols(0), _resize_chunk(2), _data(NULL), _data_size(0), _own_data(true)
-  {
-    copy(in_array);
-  }
-  
-  ~safe_array()  {
-    if (_own_data) {
-      delete[] _data;
-      _data = NULL;
-    }
-  }
-  
-  
-  int64_t size() const {
-    return _len;
-  }
-
-  int64_t rows() const {
-    return _rows;
-  }
-
-  int64_t cols() const {
-    return _cols;
-  }
-
-  int64_t capacity() const {
-    return _data_size;
-  }
-
-  void resize(int64_t n_rows, int64_t n_cols) {
-    _rows = n_rows;
-    _cols = n_cols;
-    
-    resize(_rows * _cols);
-  }
-
-  // Copy the contents of in_array to our array
-  // resizing as appropriate.
-  void copy(const safe_array<T>& in_array) {
-    if (in_array._rows == 0)
-      resize(in_array._len);
-    else
-      resize(in_array._rows,in_array._cols);
-      
-    for (int64_t i=0; i<_len; i++)
-      _data[i] = in_array[i];
-  }
-
-  
-  void resize(int64_t new_length) {
-#ifdef NEC_ERROR_CHECK
-    if (! _own_data)
-      throw new nec_exception("attempt to resize data we do not own");
-#endif
-    if (new_length > _data_size) {
-      // geometric growth to avoid O(n²) reallocation when repeatedly
-      // growing by small increments.
-      _data_size = new_length * 2;
-      try {
-        T* new_data_ = new T[_data_size];
-        if (0 != _len)
-          std::memcpy(new_data_, _data, static_cast<size_t>(_len) * sizeof(T));
-
-        delete[] _data;
-        _data = new_data_;
-      } catch (std::bad_alloc& ba) {
-        throw new nec_exception("Error: Out of Memory ");
-      }
-    }
-    _len = new_length;
-  }
-  
-  /*!\brief return the largest element of the array */
-  T maxCoeff() const {
-    if (0 == _len)
-      throw new nec_exception("No elements in maxCoeff");
-
-    T ret = _data[check(0)];
-    
-    for (int64_t i = 1; i < _len; i++ ) {
-      if ( _data[check(i)] > ret)
-        ret = _data[check(i)];
-    }
-    return ret;
-  }
-
-  /*!\brief return the largest element of the array */
-  T minCoeff() const {
-    if (int64_t(0) == _len)
-      throw new nec_exception("No elements in minCoeff");
-
-    T ret = _data[check(0)];
-    
-    for (int64_t i = 1; i < _len; i++ ) {
-      if ( _data[check(i)] < ret)
-        ret = _data[check(i)];
-    }
-    return ret;
-  }
-
-  /*!\brief return the sum of the specified elements in the array */
-  T sum(int64_t start_index, int64_t stop_index)  {
-    T ret = _data[check(start_index)];
-    
-    for (int64_t i = start_index+1; i < stop_index; i++ )  {
-      ret += _data[check(i)];
-    }
-    return ret;
-  }
-
-  /*!\brief return the sum of all elements in the array */
-  T sum() {
-    return sum(0,_len);
-  }
-
-  // fill specified elements of the array with x
-  void fill(int64_t start, int64_t N, const T& x) {
-    int64_t stop = start + N;
-    for (int64_t i = start; i < stop; i++ ) {
-      _data[check(i)] = x;
-    }
-  }
-  
-  // fill all elements of the array with x
-  void setConstant(const T& x)  {
-    fill(0,_len,x);
-  }
-
-  /*! \brief Set an element assuming that the data is stored in column major form.
-  */
-  void set_col_major(int64_t col_dim, int64_t col, int64_t row, const T& val) {
-    _data[check(row*col_dim + col)] = val;
-  }
-
-  /*! \brief Get an element assuming that the data is stored in column major form.
-  */
-  T& get_col_major(int64_t col_dim, int64_t col, int64_t row) {
-    return _data[check(row*col_dim + col)];
-  }
-  
-  
-  /**
-   * \remark This is an accessor function that is useful for wrapping.
-   * */
-  T& getItem(int64_t row, int64_t col) {
-    return _data[check(row,col)];
-  }
-
-  
-  /**
-   * \remark We use round brackets for indexing into 2D arrays.
-   * */
-  T& operator()(int64_t row, int64_t col)  {
-    return getItem(row, col);
-  }
-  
-  const T& operator()(int64_t row, int64_t col) const  {
-    return _data[check(row,col)];
-  }
-  
-  /* \brief An accessor method to help with wrapping the C++ objects
-  * into other languages (like python, ruby)
-  */
-  T& getItem(int64_t i) {
-    return _data[check(i)];
-  }
-  
-  const T& operator[](int64_t i) const  {
-    return _data[check(i)];
-  }
-  
-  T& operator[](int64_t i)  {
-    return getItem(i);
-  }
-  
-  /*!\brief Return a representation of a subset of this array
-      \param start_index The index of the first element
-      \param end_index If -1, then finish at the end of the array
-  */
-  safe_array<T> segment(int64_t start_index, int64_t end_index)  {
-    if (int64_t(-1) == end_index)
-      throw "foo";
-    return safe_array<T>(*this, start_index, end_index, false);
-  }
-  
-  /*!\brief Return a representation of a subset of this array
-      \param start_index The index of the first element
-      \param n Number of elements in the segment
-  */
-  safe_array<T> eigen_segment(int64_t start_index, int64_t n)  {
-    int64_t end_index = start_index + n;
-    return safe_array<T>(*this, start_index, end_index, false);
-  }
-  
-  
-  T* data() const  {
-    return _data;
-  }
-                  
-  safe_array<T>& operator=(const safe_array<T>& in_array)  {
-    copy(in_array);
-    return *this;
-  }
-          
-
-protected:
-  int64_t _len;
-  int64_t _rows;
-  int64_t _cols;
-  int64_t _resize_chunk;
-  
-  T*  _data;
-  int64_t _data_size;
-  
-  bool _own_data;
-  
-  /*!\brief Constructor only used to construct segment
-  \param start_index The first element of in_array to copy.
-  \param end_index The last element of in_array to copy.
-  \param in_copy_data True if we create a copy of data from in_array. False - just reference the data in in_array.
-  */
-  safe_array(const safe_array<T>& in_array, int64_t start_index, int64_t end_index, bool in_copy_data)
-  {
-    _resize_chunk = in_array._resize_chunk;
-    _len = (end_index - start_index)+1; // include the end_index element
-    _rows = 0;
-    _cols = 0;
-    
-    if (in_copy_data)  {
-      _data = new T[_len];
-      _data_size = _len;
-      
-      for (int64_t i=0; i<_len; i++)
-        _data[check(i)] = in_array[start_index + i];
-
-      _own_data = true;
-    } else {
-      _data = in_array.data() + start_index;
-      _data_size = 0;
-      _own_data = false;
-    }
-  }
-  
-  inline int64_t check(int64_t i) const  {
-#ifdef NEC_ERROR_CHECK
-    if (i < 0 || i >= _len)
-      throw new BoundsViol("safe_array: ", i, _len);
-#endif
-    return i;
-  }
-
-  inline int64_t check(int64_t row, int64_t col) const  {
-#ifdef NEC_ERROR_CHECK
-    if (row < 0 || row >= _rows)
-      throw new BoundsViol("safe_array: ", row, _rows);
-    if (col < 0 || col >= _cols)
-      throw new BoundsViol("safe_array: ", col, _cols);
-#endif
-    return check(int64_t(col)*_rows + row);
-  }
-}; 
-
-
-template<typename T>
-class safe_matrix : public safe_array<T> {
-public:
-  safe_matrix(int64_t in_rows, int64_t in_cols) : safe_array<T>(in_rows*in_cols) {
-    this->resize(in_rows, in_cols);
-  }
-  safe_matrix() : safe_array<T>()
-  { }
-
-
-private:
-  using safe_array<T>::operator[]; /* Stop folk from using square bracket indexing */
-
-};
-
-#endif /* USING_EIGEN_ARRAY */
 
 #endif /* __safe_array__ */


### PR DESCRIPTION
## Summary

Eigen is now mandatory. All `--with-eigen*` configure options removed. LAPACK option removed.

## Changes

### configure.ac
- Eigen detection is mandatory (fails if libeigen3-dev not installed)
- Defines `USING_EIGEN_ARRAY`, `USING_EIGEN_3VECT`, `EIGEN_LU` unconditionally
- Removes `--with-eigen`, `--with-eigenv`, `--with-eigen-lu`
- Removes `--with-lapack` and all LAPACKE detection
- `PRIVATE_LIBS` no longer includes `-llapack -lblas`

### safe_array.h
- Removes non-Eigen implementation entirely (~300 lines)
- Fixes infinite recursion in `const operator[]`
- Full Eigen::Matrix backing with write-through segment views

### math_util.h
- Removes hand-written `nec_3vector` class (~150 lines)
- `nec_3vector = Eigen::Matrix<nec_float,3,1>` always
- Simplifies typedefs

### matrix_algebra.cpp/h
- Removes LAPACK path (`lu_decompose_lapack`, `solve_lapack`, `lapacke.h`)
- Eigen LU path is unconditional
- Dispatch simplified to direct calls

### Net code reduction: **~720 lines removed**