### PR TITLE
"fix: use l1 norm in gshank convergence gate"

### DIFF
--- a/src/c_evlcom.cpp
+++ b/src/c_evlcom.cpp
@@ -186,7 +186,7 @@ void c_evlcom::gshank( nec_complex start, nec_complex dela, complex_array& sum,
 				if (den < denm)
 					den=denm;
 				a1=q1[i][j]-a1;
-				amg=fabs(real(a1)+fabs(imag(a1)));
+				amg=fabs(real(a1))+fabs(imag(a1));
 				if (amg > den)
 				{
 					brk = true;

--- a/testharness/c_src/somnec.c
+++ b/testharness/c_src/somnec.c
@@ -624,7 +624,7 @@ void gshank( complex long double start, complex long double dela, complex long d
 	if(den < denm)
 	  den=denm;
 	a1=q1[i][j]-a1;
-	amg=fabsl(creal(a1)+fabsl(cimag(a1)));
+	amg=fabsl(creal(a1))+fabsl(cimag(a1));
 	if(amg > den)
 	{
 	  brk = TRUE;


### PR DESCRIPTION
## Description

The Sommerfeld `gshank` Shank-acceleration convergence gate evaluated `fabs(real(a1)+fabs(imag(a1)))`, computing `|Re(a1) + |Im(a1)||` rather than the intended L1 taxicab magnitude `|Re(a1)| + |Im(a1)|` of the complex increment `a1`. The two forms coincide only when `Re(a1) >= 0`; for `Re(a1) < 0` the defective form cancels the real magnitude against the imaginary magnitude, understates the increment, and can admit a false convergence, corrupting the ground-wave interpolation grid under Sommerfeld ground (`GN 2`).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Implementation Details

Physics and correctness basis:

- `amg` is the running bound `den` in the convergence test; the L1 norm of a complex value is `|Re| + |Im|` by definition, so the fix rests on the norm identity rather than lineage or quorum.
- Fortran `GSHANK` writes two independent intrinsics, `AMG=ABS(DREAL(A1))+ABS(DIMAG(A1))`, the correctness oracle. The defective C form has no Fortran counterpart. It is most likely a transcription typo, a misplaced closing parenthesis introduced during the original Fortran-to-nec2c port, which then propagated into the C lineage (`nec2c` to `{necpp, xnec2c}`); the Fortran lineage `nec2dx.f` to `nec2dxs` is unaffected.

Changes:

- `src/c_evlcom.cpp` (`c_evlcom::gshank`): close `fabs` around `real(a1)` alone so `amg = |Re(a1)| + |Im(a1)|`.
- `testharness/c_src/somnec.c`: apply the identical L1 correction with `fabsl` in the long-double harness copy that feeds the `c_evlcom_tb` unit test.

Measured cross-engine impact (worst deck below, 3.6 MHz, `GN 2`, feed `TAG 6 SEG 6`):

- This norm fix is null in isolation on that deck; the divergent far-region nodes never reach the accept-gate there, so the impedance stays `291.31 + j0.47733`. Combined with the companion `evlua` contour fix the C engines collapse onto the Fortran `nec2dxs` reference `298.908 + j5.878`. Inclusion here rests on norm correctness and Fortran fidelity.

Reproduction deck (`3r6-bruce-5sect-12.nec`, 80m Bruce array over Sommerfeld ground):

```
CM 80m dipole
CE
GW 1,5,0.,-32.8939,12.49135,0.,-44.96888,12.49135,.0010262
GW 2,11,0.,-44.96888,12.49135,0.,-44.96888,33.72666,.0010262
GW 3,11,0.,-44.96888,33.72666,0.,-22.48444,33.72666,.0010262
GW 4,11,0.,-22.48444,33.72666,0.,-22.48444,12.49135,.0010262
GW 5,11,0.,-22.48444,12.49135,0.,0.,12.49135,.0010262
GW 6,11,0.,0.,12.49135,0.,0.,33.72666,.0010262
GW 7,11,0.,0.,33.72666,0.,22.48444,33.72666,.0010262
GW 8,11,0.,22.48444,33.72666,0.,22.48444,12.49135,.0010262
GW 9,11,0.,22.48444,12.49135,0.,44.96888,12.49135,.0010262
GW 10,11,0.,44.96888,12.49135,0.,44.96888,33.72666,.0010262
GW 11,5,0.,44.96888,33.72666,0.,32.8939,33.72666,.0010262
GE 1
LD 5,1,0,0, 5.7471E+7,1.
LD 5,2,0,0, 5.7471E+7,1.
LD 5,3,0,0, 5.7471E+7,1.
LD 5,4,0,0, 5.7471E+7,1.
LD 5,5,0,0, 5.7471E+7,1.
LD 5,6,0,0, 5.7471E+7,1.
LD 5,7,0,0, 5.7471E+7,1.
LD 5,8,0,0, 5.7471E+7,1.
LD 5,9,0,0, 5.7471E+7,1.
LD 5,10,0,0, 5.7471E+7,1.
LD 5,11,0,0, 5.7471E+7,1.
FR 0,1,0,0,3.6
GN 2,0,0,0,13.,.005
EX 0,6,6,0,1.414214,0.
RP 0,181,1,1000,90.,0.,-1.,0.,0.
EN
```

## Testing

- [ ] `c_evlcom_tb` harness exercises `gshank`; unit test not re-run in this changeset