### PR TITLE
"fix: complete evlua sommerfeld contour via three-way branch selection"

### DIFF
--- a/src/c_evlcom.cpp
+++ b/src/c_evlcom.cpp
@@ -563,54 +563,52 @@ void c_evlcom::evlua( nec_complex *erv, nec_complex *ezv,
 	gshank(cp1,delta,ans,6,sum,0,bk,bk);
 	rmis=m_rho*(real(m_ck1)-m_ck2);
 	
-	bool jump = false;
-	if ( (rmis >= 2.*m_ck2) && (m_rho >= 1.e-10) )
-	{
-		if (m_zph >= 1.e-10)
-		{
-			bk=nec_complex(-m_zph,m_rho)*(m_ck1-cp3);
-			rmis = -real(bk)/fabs(imag(bk));
-			if (rmis > 4.*m_rho/m_zph)
-				jump = true;
-		}
-		
-		if ( false == jump )
-		{
-			/* integrate up between branch cuts, then to + infinity */
-			cp1=m_ck1- nec_complex(0.1,+0.2);
-			cp2=cp1+.2;
-			bk=nec_complex(0.,del);
-			gshank(cp1,bk,sum,6,ans,0,bk,bk);
-			m_contour_a=cp1;
-			m_contour_b=cp2;
-			rom1(6,ans,1);
-			for (int i = 0; i < 6; i++ )
-				ans[i] -= sum[i];
-			
-			gshank(cp3,bk,sum,6,ans,0,bk,bk);
-			gshank(cp2,delta2,ans,6,sum,0,bk,bk);
-		}
-		
-		jump = true;	
-	} /* if ( (rmis >= 2.*m_ck2) || (m_rho >= 1.e-10) ) */
-	else
+	bool jump;
+	if ( (rmis < 2.*m_ck2) || (m_rho < 1.e-10) )
+		jump = true;
+	else if ( m_zph < 1.e-10 )
 		jump = false;
-	
+	else
+	{
+		bk=nec_complex(-m_zph,m_rho)*(m_ck1-cp3);
+		rmis = -real(bk)/fabs(imag(bk));
+		if (rmis > 4.*m_rho/m_zph)
+			jump = true;
+		else
+			jump = false;
+	}
+
 	if ( false == jump )
+	{
+		/* integrate up between branch cuts, then to + infinity */
+		cp1=m_ck1- nec_complex(0.1,+0.2);
+		cp2=cp1+.2;
+		bk=nec_complex(0.,del);
+		gshank(cp1,bk,sum,6,ans,0,bk,bk);
+		m_contour_a=cp1;
+		m_contour_b=cp2;
+		rom1(6,ans,1);
+		for (int i = 0; i < 6; i++ )
+			ans[i] -= sum[i];
+
+		gshank(cp3,bk,sum,6,ans,0,bk,bk);
+		gshank(cp2,delta2,ans,6,sum,0,bk,bk);
+	}
+	else
 	{
 		/* integrate below branch points, then to + infinity */
 		for (int i = 0; i < 6; i++ )
 			sum[i] = -ans[i];
-		
+
 		rmis=real(m_ck1)*1.01;
 		if ( (m_ck2+1.) > rmis )
 			rmis=m_ck2+1.;
-		
+
 		bk=nec_complex(rmis,.99*imag(m_ck1));
 		delta=bk-cp3;
 		delta *= del/abs(delta);
 		gshank(cp3,delta,ans,6,sum,1,bk,delta2);
-	} /* if ( false == jump ) */
+	}
 	
 	ans[5] *= m_ck1;
 	

--- a/testharness/c_src/somnec.c
+++ b/testharness/c_src/somnec.c
@@ -357,41 +357,37 @@ void evlua( complex long double *erv, complex long double *ezv,
   gshank(cp1,delta,ans,6,sum,0,bk,bk);
   rmis=rho*(creal(ck1)-ck2);
 
-  jump = FALSE;
-  if( (rmis >= 2.*ck2) && (rho >= 1.e-10) )
-  {
-    if(zph >= 1.e-10)
-    {
-      bk=cmplx(-zph,rho)*(ck1-cp3);
-      rmis=-creal(bk)/fabsl(cimag(bk));
-      if(rmis > 4.*rho/zph)
-	jump = TRUE;
-    }
-
-    if( ! jump )
-    {
-      /* integrate up between branch cuts, then to + infinity */
-      cp1=ck1-(.1+.2fj);
-      cp2=cp1+.2;
-      bk=cmplx(0.,del);
-      gshank(cp1,bk,sum,6,ans,0,bk,bk);
-      a=cp1;
-      b=cp2;
-      rom1(6,ans,1);
-      for( i = 0; i < 6; i++ )
-	ans[i] -= sum[i];
-
-      gshank(cp3,bk,sum,6,ans,0,bk,bk);
-      gshank(cp2,delta2,ans,6,sum,0,bk,bk);
-    }
-
+  if( (rmis < 2.*ck2) || (rho < 1.e-10) )
     jump = TRUE;
-
-  } /* if( (rmis >= 2.*ck2) || (rho >= 1.e-10) ) */
-  else
+  else if( zph < 1.e-10 )
     jump = FALSE;
+  else
+  {
+    bk=cmplx(-zph,rho)*(ck1-cp3);
+    rmis=-creal(bk)/fabsl(cimag(bk));
+    if(rmis > 4.*rho/zph)
+      jump = TRUE;
+    else
+      jump = FALSE;
+  }
 
   if( ! jump )
+  {
+    /* integrate up between branch cuts, then to + infinity */
+    cp1=ck1-(.1+.2fj);
+    cp2=cp1+.2;
+    bk=cmplx(0.,del);
+    gshank(cp1,bk,sum,6,ans,0,bk,bk);
+    a=cp1;
+    b=cp2;
+    rom1(6,ans,1);
+    for( i = 0; i < 6; i++ )
+      ans[i] -= sum[i];
+
+    gshank(cp3,bk,sum,6,ans,0,bk,bk);
+    gshank(cp2,delta2,ans,6,sum,0,bk,bk);
+  }
+  else
   {
     /* integrate below branch points, then to + infinity */
     for( i = 0; i < 6; i++ )
@@ -405,8 +401,7 @@ void evlua( complex long double *erv, complex long double *ezv,
     delta=bk-cp3;
     delta *= del/cabs(delta);
     gshank(cp3,delta,ans,6,sum,1,bk,delta2);
-
-  } /* if( ! jump ) */
+  }
 
   ans[5] *= ck1;
 


### PR DESCRIPTION
## Description

`EVLUA` closes the Sommerfeld spectral integral along a deformed contour that must be finished by exactly one of two tail integrations. In `c_evlcom::evlua` the reference decision ladder had been collapsed onto a single reused `jump` flag during the hand port from Fortran. On the large `rho/zph` branch (`rmis > 4*rho/zph`, the far interpolation region) that flag was set true early to skip the between-cuts tail (label 6) and then set true again unconditionally, so the below-branch tail (label 8) was skipped as well. The routine finished neither tail and returned an incomplete contour integral, wrong by definition; the omitted segment carries a pole and branch-cut contribution, producing near phase-opposite far-region grid values under Sommerfeld ground (`GN 2`).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues

See also: #110

This defect was discovered alongside the `gshank` L1-norm fix in #110. The measured collapse onto the Fortran reference requires both changes together; treat #110 as a companion and a potential dependency for reproducing the full impedance recovery.

## Implementation Details

Physics and correctness basis:

- The Fortran `EVLUA` linear `GO TO` ladder always reaches exactly one tail: `RMIS<2*CK2` or `RHO<1e-10` go to 8 (below the branch points); `ZPH<1e-10` goes to 6 (up between the branch cuts); `RMIS>4*RHO/ZPH` goes to 8; fall-through takes 6. Every path finishes the contour, so completeness is the correctness oracle, not lineage or quorum.
- The collapse of that ladder onto one reused flag is a transcription artifact of the hand port and lives only in the NEC lineage (`nec2c` to `{necpp, xnec2c}`); the Fortran lineage `nec2dx.f` to `nec2dxs` is unaffected.

Changes:

- `src/c_evlcom.cpp` (`c_evlcom::evlua`): replace the single `jump` flag with a three-way selection so exactly one of the label-6 or label-8 tail integrations always runs, `jump` true meaning the below-branch tail, preserving the Fortran decision order.
- `testharness/c_src/somnec.c`: apply the identical three-way selection in the long-double harness copy that feeds the `c_evlcom_tb` unit test.

Measured cross-engine impact, worst deck `3r6-bruce-5sect-12` at 3.6 MHz over Sommerfeld ground (`GN 2`, feed `TAG 6 SEG 6`):

| build                          | R (ohm)  | X (ohm)  |
|--------------------------------|----------|----------|
| defective necpp                | 291.31   | 0.47734  |
| fixed necpp (this + #110)      | 298.92   | 5.9946   |
| Fortran nec2dxs reference      | 298.908  | 5.87848  |

The residual `necpp` reactance (`j5.9946` versus `j5.87848`) tracks necpp independent matrix arithmetic and build flags rather than any residual contour issue.

Reproduction deck (`3r6-bruce-5sect-12.nec`, 80m Bruce array over Sommerfeld ground):

```
CM 80m dipole
CE
GW 1,5,0.,-32.8939,12.49135,0.,-44.96888,12.49135,.0010262
GW 2,11,0.,-44.96888,12.49135,0.,-44.96888,33.72666,.0010262
GW 3,11,0.,-44.96888,33.72666,0.,-22.48444,33.72666,.0010262
GW 4,11,0.,-22.48444,33.72666,0.,-22.48444,12.49135,.0010262
GW 5,11,0.,-22.48444,12.49135,0.,0.,12.49135,.0010262
GW 6,11,0.,0.,12.49135,0.,0.,33.72666,.0010262
GW 7,11,0.,0.,33.72666,0.,22.48444,33.72666,.0010262
GW 8,11,0.,22.48444,33.72666,0.,22.48444,12.49135,.0010262
GW 9,11,0.,22.48444,12.49135,0.,44.96888,12.49135,.0010262
GW 10,11,0.,44.96888,12.49135,0.,44.96888,33.72666,.0010262
GW 11,5,0.,44.96888,33.72666,0.,32.8939,33.72666,.0010262
GE 1
LD 5,1,0,0, 5.7471E+7,1.
LD 5,2,0,0, 5.7471E+7,1.
LD 5,3,0,0, 5.7471E+7,1.
LD 5,4,0,0, 5.7471E+7,1.
LD 5,5,0,0, 5.7471E+7,1.
LD 5,6,0,0, 5.7471E+7,1.
LD 5,7,0,0, 5.7471E+7,1.
LD 5,8,0,0, 5.7471E+7,1.
LD 5,9,0,0, 5.7471E+7,1.
LD 5,10,0,0, 5.7471E+7,1.
LD 5,11,0,0, 5.7471E+7,1.
FR 0,1,0,0,3.6
GN 2,0,0,0,13.,.005
EX 0,6,6,0,1.414214,0.
RP 0,181,1,1000,90.,0.,-1.,0.,0.
EN
```

## Testing

- [ ] `c_evlcom_tb` harness exercises `evlua`; unit test not re-run in this changeset