### PR TITLE
c_geometry: write parsed fields back on trailing-field cards

### DIFF
--- a/src/c_geometry.cpp
+++ b/src/c_geometry.cpp
@@ -2455,6 +2455,18 @@ void c_geometry::parse_geometry_card_line(const char* line_buf, char *gm,
       return;
     }
   }
+
+  /*
+   * Write the parsed fields back on normal loop exit. A card carrying more
+   * numeric fields than the two integers and seven reals this reader consumes
+   * leaves line_idx short of the terminator, so the in-loop end-of-string
+   * writes never fire; without this the caller's reused parse state retains the
+   * previous card's values.
+   */
+  *in_i1= integer_params[0]; *in_i2= integer_params[1];
+  *in_x1= real_params[0]; *in_y1= real_params[1]; *in_z1= real_params[2];
+  *in_x2= real_params[3]; *in_y2= real_params[4]; *in_z2= real_params[5];
+  *in_rad= real_params[6];
 }
 
 void c_geometry::read_geometry_card(FILE* input_fp,  char *gm,


### PR DESCRIPTION
## Description

The shared geometry card parser only wrote its output pointers inside the in-loop end-of-string guards. A card carrying more numeric fields than the two integers and seven reals the reader consumes left `line_idx` short of the terminator, so the write-back never fired and the caller (which reuses one parse state across every card) retained the previous card values.

Concretely a `GM` move card took its repeat count from a preceding `GA` arc segment count and replicated the whole structure, exploding the segment total. The regression came from 220977d, which extracted the shared parser and dropped the unconditional write-back that the nec2c and xnec2c ancestors retain.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Implementation Details

Restore the unconditional write-back of the parsed integers and reals at the normal loop-exit of the shared geometry card parser, repairing every geometry card type that carries trailing fields.

## Testing

Reproduce with cebik `84-8.nec`, whose 12-field `GM` card after two 90-segment `GA` arcs yielded 16380 segments instead of 180 and ran multi-hour at 8 GB:

```
CM 2-element circular quad beam
CE
GA 1 90 .1572 0 360 .001
GA 2 90 .1722 0 360 .001
GM 0 0 0 0 0 0 .1665 0 2 0 0 0
GE 0 -1 0
EX 0 1 68 0 1.0 0.0
FR 0 1 0 0 299.8 1
RP 0 1 361 1000 90 0 1 1
EN
```
