### PR TITLE
Bump version to 2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Version 2.1.2
+## Version 2.2.0
 
 ### Modernization
 * All `fprintf(stderr, ...)` replaced with `std::cerr` (misc.cpp, nec2cpp.cpp, nec_output.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@
 cmake_minimum_required(VERSION 3.16)
 
 project(necpp
-    VERSION 2.1.1
+    VERSION 2.2.0
     DESCRIPTION "NEC2++ antenna modelling library and tools"
     HOMEPAGE_URL "https://github.com/tmolteno/necpp"
     LANGUAGES CXX)


### PR DESCRIPTION
Bumps the project version from 2.1.1 to 2.2.0 to mark the CMake migration (PR #116) and related build-system work as a release.

- `CMakeLists.txt`: `VERSION 2.1.1` → `2.2.0`
- `CHANGELOG.md`: top (unreleased) entry heading renamed to `Version 2.2.0`

Verified: `PROJECT_VERSION_MAJOR` stays `2`, so the shared-library soname (`libnecpp2`) and Debian/RPM runtime package names (`libnecpp2`) are unchanged — appropriate for a minor bump, no ABI break.