### PR TITLE
misc: fix over-length input lines and card buffer sizing

### DIFF
--- a/src/c_geometry.cpp
+++ b/src/c_geometry.cpp
@@ -2475,7 +2475,7 @@ void c_geometry::read_geometry_card(FILE* input_fp,  char *gm,
   nec_float *in_x2, nec_float *in_y2, nec_float *in_z2,
   nec_float *in_rad )
 {
-  char line_buf[134];
+  char line_buf[LINE_LEN+1];
   load_line( line_buf, input_fp );
   parse_geometry_card_line(line_buf, gm, in_i1, in_i2, in_x1, in_y1, in_z1, in_x2, in_y2, in_z2, in_rad);
 }
@@ -2486,7 +2486,7 @@ void c_geometry::read_geometry_card(std::istream& is,  char *gm,
   nec_float *in_x2, nec_float *in_y2, nec_float *in_z2,
   nec_float *in_rad )
 {
-  char line_buf[134];
+  char line_buf[LINE_LEN+1];
   load_line( line_buf, is );
   parse_geometry_card_line(line_buf, gm, in_i1, in_i2, in_x1, in_y1, in_z1, in_x2, in_y2, in_z2, in_rad);
 }

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -120,7 +120,13 @@ int load_line( char *buff, FILE *pfile )
 			eof = EOF;
 		}
 	} /* end of while( num_chr < max_chr ) */
-	
+
+	/* drain any characters past LINE_LEN so an over-length line
+	 * cannot leak its tail into the next load_line read */
+	while( (chr != CR) && (chr != LF) )
+		if( (chr = fgetc(pfile)) == EOF )
+			break;
+
 	/* Capitalize first two characters (mnemonics) */
 	    buff[0] = static_cast<char>(std::toupper(buff[0]));
 	    buff[1] = static_cast<char>(std::toupper(buff[1]));
@@ -173,6 +179,13 @@ int load_line( char *buff, std::istream& is )
 			buff[num_chr] = '\0';
 			eof = EOF;
 		}
+	}
+
+	/* drain any characters past LINE_LEN so an over-length line
+	 * cannot leak its tail into the next load_line read */
+	while ( (chr != CR) && (chr != LF) ) {
+		chr = is.get();
+		if ( !is ) break;
 	}
 
 	buff[0] = static_cast<char>(std::toupper(buff[0]));

--- a/src/misc.h
+++ b/src/misc.h
@@ -9,7 +9,7 @@
 #define	LF	0x0a
 
 /* max length of a line read from input file */
-#define	LINE_LEN	132
+#define	LINE_LEN	512
 
 /*  usage()
  *

--- a/src/nec2cpp.cpp
+++ b/src/nec2cpp.cpp
@@ -445,7 +445,7 @@ int readmn(std::istream& is,
 	nec_float *f1, nec_float *f2, nec_float *f3,
 	nec_float *f4, nec_float *f5, nec_float *f6 )
 {
-	char line_buf[134];
+	char line_buf[LINE_LEN+1];
 
 	int eof = load_line( line_buf, is );
 	int line_length = static_cast<int>(strlen( line_buf ));
@@ -480,7 +480,7 @@ int readmn(FILE* input_fp, FILE* output_fp,
 	nec_float *f1, nec_float *f2, nec_float *f3,
 	nec_float *f4, nec_float *f5, nec_float *f6 )
 {
-	char line_buf[134];
+	char line_buf[LINE_LEN+1];
 
 	int eof = load_line( line_buf, input_fp );
 	int line_length = static_cast<int>(strlen( line_buf ));

--- a/testharness/c_src/geometry.c
+++ b/testharness/c_src/geometry.c
@@ -1711,7 +1711,7 @@ void subph( int nx, int ny )
 void readgm( char *gm, int *i1, int *i2, long double *x1, long double *y1,
     long double *z1, long double *x2, long double *y2, long double *z2, long double *rad )
 {
-  char line_buf[134];
+  char line_buf[LINE_LEN+1];
   int nlin, i, line_idx;
   int nint = 2, nflt = 7;
   int iarr[2] = { 0, 0 };

--- a/testharness/c_src/input.c
+++ b/testharness/c_src/input.c
@@ -242,7 +242,7 @@ void readmn( char *gm, int *i1, int *i2, int *i3, int *i4,
     long double *f1, long double *f2, long double *f3,
     long double *f4, long double *f5, long double *f6 )
 {
-  char line_buf[134];
+  char line_buf[LINE_LEN+1];
   int nlin, i, line_idx;
   int nint = 4, nflt = 6;
   int iarr[4] = { 0, 0, 0, 0 };

--- a/testharness/c_src/main.c
+++ b/testharness/c_src/main.c
@@ -128,7 +128,7 @@ static void sig_handler( int signal );
 int main( int argc, char **argv )
 {
   char infile[81] = "", otfile[81] = "";
-  char ain[3], line_buf[81];
+  char ain[3], line_buf[LINE_LEN+1];
 
   /* input card mnemonic list */
 #define NUM_CMNDS  20

--- a/testharness/c_src/nec2c.h
+++ b/testharness/c_src/nec2c.h
@@ -78,7 +78,7 @@
 #define	LF	0x0a
 
 /* max length of a line read from input file */
-#define	LINE_LEN	132/* version of fortran source for the -v option */
+#define	LINE_LEN	512/* version of fortran source for the -v option */
 #define		version "nec2c v0.1"
 
 /* Function prototypes */


### PR DESCRIPTION
## Description

Corrects two `load_line` input-handling defects surfaced by the `xnec2c-validation-data` corpus: decks the Fortran reference peers (`nec2dx`/`nec2dxs`) already solve, but failed under `nec2++`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Implementation Details

- **Drain over-length input lines** (`src/misc.cpp`, both `load_line` overloads). The fill loop stops at `LINE_LEN` without consuming the rest of a longer physical line, so a curated archival-URL `CM` comment truncates and its tail is read on the next call as a spurious card, failing with `ERROR: INCORRECT LABEL FOR A COMMENT CARD`. After the loop, drain remaining characters up to `CR`/`LF`, mirroring the existing inline-comment drain.

- **Size card buffers to `LINE_LEN+1`** (`src/nec2cpp.cpp`, `src/c_geometry.cpp`, testharness `c_src/`). Callers hard-coded `line_buf[134]`/`line_buf[81]` rather than deriving from `LINE_LEN`; the `81`-byte buffer was a genuine overflow. Every card buffer now binds to `line_buf[LINE_LEN+1]`, tracking the define as a single point of truth.

NEC free-field comma delimiters are already handled by `parse_nec_card` (`src/nec_card_parser.h`); the comma decks were only blocked by the long-`CM` truncation above.

_Side note:_ `LINE_LEN` raised `132 -> 512`; the `LINE_LEN+1` buffers scale with it.

## Testing

- [x] Tests pass locally

Catch2 suite plus the hertzian-dipole smoke test pass 2/2 via `ctest`. `nec2++` solved 5 of 5 on the targeted long-`CM` set (`15-4a`, `19-7-nec2`) and the comma-delimited decks behind them (`nec4-deck1`, `corner4-deck2`, `10-10`).