### PR TITLE
test(load_line): harden over-length drain + add regression coverage (follow-up to #118)

### DIFF
--- a/src/c_geometry.cpp
+++ b/src/c_geometry.cpp
@@ -2475,7 +2475,7 @@ void c_geometry::read_geometry_card(FILE* input_fp,  char *gm,
   nec_float *in_x2, nec_float *in_y2, nec_float *in_z2,
   nec_float *in_rad )
 {
-  char line_buf[134];
+  char line_buf[LINE_LEN+1];
   load_line( line_buf, input_fp );
   parse_geometry_card_line(line_buf, gm, in_i1, in_i2, in_x1, in_y1, in_z1, in_x2, in_y2, in_z2, in_rad);
 }
@@ -2486,7 +2486,7 @@ void c_geometry::read_geometry_card(std::istream& is,  char *gm,
   nec_float *in_x2, nec_float *in_y2, nec_float *in_z2,
   nec_float *in_rad )
 {
-  char line_buf[134];
+  char line_buf[LINE_LEN+1];
   load_line( line_buf, is );
   parse_geometry_card_line(line_buf, gm, in_i1, in_i2, in_x1, in_y1, in_z1, in_x2, in_y2, in_z2, in_rad);
 }

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -120,7 +120,13 @@ int load_line( char *buff, FILE *pfile )
 			eof = EOF;
 		}
 	} /* end of while( num_chr < max_chr ) */
-	
+
+	/* drain any characters past LINE_LEN so an over-length line
+	 * cannot leak its tail into the next load_line read */
+	while( (chr != CR) && (chr != LF) )
+		if( (chr = fgetc(pfile)) == EOF )
+			break;
+
 	/* Capitalize first two characters (mnemonics) */
 	    buff[0] = static_cast<char>(std::toupper(buff[0]));
 	    buff[1] = static_cast<char>(std::toupper(buff[1]));
@@ -173,6 +179,13 @@ int load_line( char *buff, std::istream& is )
 			buff[num_chr] = '\0';
 			eof = EOF;
 		}
+	}
+
+	/* drain any characters past LINE_LEN so an over-length line
+	 * cannot leak its tail into the next load_line read */
+	while ( (chr != CR) && (chr != LF) ) {
+		chr = is.get();
+		if ( !is ) break;
 	}
 
 	buff[0] = static_cast<char>(std::toupper(buff[0]));

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -119,13 +119,18 @@ int load_line( char *buff, FILE *pfile )
 			buff[num_chr] = '\0';
 			eof = EOF;
 		}
-	} /* end of while( num_chr < max_chr ) */
+	} /* end of while( num_chr < LINE_LEN ) */
 
 	/* drain any characters past LINE_LEN so an over-length line
-	 * cannot leak its tail into the next load_line read */
+	 * cannot leak its tail into the next load_line read. Match the
+	 * fill loop's EOF convention (set eof, fall through) rather than
+	 * the single-quote drain's early return, so the buffer's mnemonic
+	 * is still capitalized/terminated and the caller sees EOF. */
 	while( (chr != CR) && (chr != LF) )
-		if( (chr = fgetc(pfile)) == EOF )
+		if( (chr = fgetc(pfile)) == EOF ) {
+			eof = EOF;
 			break;
+		}
 
 	/* Capitalize first two characters (mnemonics) */
 	    buff[0] = static_cast<char>(std::toupper(buff[0]));
@@ -182,10 +187,14 @@ int load_line( char *buff, std::istream& is )
 	}
 
 	/* drain any characters past LINE_LEN so an over-length line
-	 * cannot leak its tail into the next load_line read */
+	 * cannot leak its tail into the next load_line read. Match the
+	 * fill loop's EOF convention (set eof, fall through). */
 	while ( (chr != CR) && (chr != LF) ) {
 		chr = is.get();
-		if ( !is ) break;
+		if ( !is ) {
+			eof = EOF;
+			break;
+		}
 	}
 
 	buff[0] = static_cast<char>(std::toupper(buff[0]));

--- a/src/misc.h
+++ b/src/misc.h
@@ -9,7 +9,7 @@
 #define	LF	0x0a
 
 /* max length of a line read from input file */
-#define	LINE_LEN	132
+#define	LINE_LEN	512
 
 /*  usage()
  *

--- a/src/nec2cpp.cpp
+++ b/src/nec2cpp.cpp
@@ -445,7 +445,7 @@ int readmn(std::istream& is,
 	nec_float *f1, nec_float *f2, nec_float *f3,
 	nec_float *f4, nec_float *f5, nec_float *f6 )
 {
-	char line_buf[134];
+	char line_buf[LINE_LEN+1];
 
 	int eof = load_line( line_buf, is );
 	int line_length = static_cast<int>(strlen( line_buf ));
@@ -480,7 +480,7 @@ int readmn(FILE* input_fp, FILE* output_fp,
 	nec_float *f1, nec_float *f2, nec_float *f3,
 	nec_float *f4, nec_float *f5, nec_float *f6 )
 {
-	char line_buf[134];
+	char line_buf[LINE_LEN+1];
 
 	int eof = load_line( line_buf, input_fp );
 	int line_length = static_cast<int>(strlen( line_buf ));

--- a/src/nec2cpp_tb.cpp
+++ b/src/nec2cpp_tb.cpp
@@ -20,6 +20,7 @@ int readmn(FILE* input_fp, FILE* output_fp, char *gm, int *i1, int *i2,
 
 /* load_line() declaration */
 int load_line( char *buff, FILE *pfile );
+int load_line( char *buff, std::istream& is );
 
 /* Stream-based readmn declaration */
 int readmn(std::istream& is,
@@ -268,4 +269,84 @@ TEST_CASE("parse_nec_card matches old readmn for EX", "[compat]") {
     REQUIRE(c_new.i[3] == c_old.i[3]);
     for (int n = 0; n < 6; n++)
         REQUIRE(c_new.f[n] == c_old.f[n]);
+}
+
+/*-----------------------------------------------------------------------*/
+/* load_line(): over-length line handling.
+ *
+ * Regression coverage for the fix behind PR #118: a physical line longer
+ * than LINE_LEN must not leak its tail into the next load_line() read.
+ * The original fill loop stopped at LINE_LEN without consuming the rest of
+ * the line, so an over-length CM comment was truncated and its tail was
+ * returned by the next call as a spurious card, failing the CM/CE comment
+ * check even when the deck legitimately closed its comment block with CE.
+ */
+
+/* A CM line that exceeds LINE_LEN by a comfortable margin. Its exact
+ * content past the mnemonic is irrelevant to the bug; it only needs to be
+ * long enough to overflow the fill buffer. */
+static std::string make_long_comment_line() {
+    std::string s = "CM";
+    while (static_cast<int>(s.size()) < LINE_LEN + 64)
+        s += 'x';
+    return s;
+}
+
+TEST_CASE("load_line(FILE*) drains over-length CM, next line parses as CE",
+          "[load_line]") {
+    std::string long_cm = make_long_comment_line();
+    std::string deck = long_cm + "\nCE end of comment block\n";
+
+    /* Write to a temporary file (auto-removed on fclose). */
+    FILE* fp = std::tmpfile();
+    REQUIRE(fp != nullptr);
+    std::fputs(deck.c_str(), fp);
+    std::rewind(fp);
+
+    char buf[LINE_LEN + 1];
+
+    /* First read: the over-length CM. It must be recognized as CM and its
+     * tail must NOT bleed into the next read. */
+    REQUIRE(load_line(buf, fp) == 0);
+    REQUIRE(buf[0] == 'C');
+    REQUIRE(buf[1] == 'M');
+
+    /* Second read must be the CE line, not the leftover tail of the CM. */
+    REQUIRE(load_line(buf, fp) == 0);
+    REQUIRE(buf[0] == 'C');
+    REQUIRE(buf[1] == 'E');
+
+    std::fclose(fp);
+}
+
+TEST_CASE("load_line(istream) drains over-length CM, next line parses as CE",
+          "[load_line]") {
+    std::string long_cm = make_long_comment_line();
+    std::string deck = long_cm + "\nCE end of comment block\n";
+    std::istringstream is(deck);
+
+    char buf[LINE_LEN + 1];
+
+    REQUIRE(load_line(buf, is) == 0);
+    REQUIRE(buf[0] == 'C');
+    REQUIRE(buf[1] == 'M');
+
+    REQUIRE(load_line(buf, is) == 0);
+    REQUIRE(buf[0] == 'C');
+    REQUIRE(buf[1] == 'E');
+}
+
+TEST_CASE("load_line returns EOF when an over-length line is the last line",
+          "[load_line]") {
+    /* No trailing newline: the drain hits EOF mid-tail. The fill loop's
+     * convention is to set eof and fall through (not early-return), so the
+     * caller gets EOF on this same call. */
+    std::string long_cm = make_long_comment_line();   // no trailing '\n'
+    std::istringstream is(long_cm);
+
+    char buf[LINE_LEN + 1];
+    REQUIRE(load_line(buf, is) == EOF);
+    /* The mnemonic is still usable despite the overflow. */
+    REQUIRE(buf[0] == 'C');
+    REQUIRE(buf[1] == 'M');
 }

--- a/testharness/c_src/geometry.c
+++ b/testharness/c_src/geometry.c
@@ -1711,7 +1711,7 @@ void subph( int nx, int ny )
 void readgm( char *gm, int *i1, int *i2, long double *x1, long double *y1,
     long double *z1, long double *x2, long double *y2, long double *z2, long double *rad )
 {
-  char line_buf[134];
+  char line_buf[LINE_LEN+1];
   int nlin, i, line_idx;
   int nint = 2, nflt = 7;
   int iarr[2] = { 0, 0 };

--- a/testharness/c_src/input.c
+++ b/testharness/c_src/input.c
@@ -242,7 +242,7 @@ void readmn( char *gm, int *i1, int *i2, int *i3, int *i4,
     long double *f1, long double *f2, long double *f3,
     long double *f4, long double *f5, long double *f6 )
 {
-  char line_buf[134];
+  char line_buf[LINE_LEN+1];
   int nlin, i, line_idx;
   int nint = 4, nflt = 6;
   int iarr[4] = { 0, 0, 0, 0 };

--- a/testharness/c_src/main.c
+++ b/testharness/c_src/main.c
@@ -128,7 +128,7 @@ static void sig_handler( int signal );
 int main( int argc, char **argv )
 {
   char infile[81] = "", otfile[81] = "";
-  char ain[3], line_buf[81];
+  char ain[3], line_buf[LINE_LEN+1];
 
   /* input card mnemonic list */
 #define NUM_CMNDS  20

--- a/testharness/c_src/nec2c.h
+++ b/testharness/c_src/nec2c.h
@@ -78,7 +78,7 @@
 #define	LF	0x0a
 
 /* max length of a line read from input file */
-#define	LINE_LEN	132/* version of fortran source for the -v option */
+#define	LINE_LEN	512/* version of fortran source for the -v option */
 #define		version "nec2c v0.1"
 
 /* Function prototypes */


### PR DESCRIPTION
Follow-up to #118 (by @KJ7LNW), implementing the three non-blocking refinements from its review.

## Summary

Layered on top of #118's commit, addressing the polish items identified during review:

### 1. EOF consistency in the new drain loops
The drain added by #118 used bare `break` on EOF, so an over-length line that is the *last line with no trailing newline* returned `0` instead of `EOF` — callers had to loop once more before seeing EOF. The pre-existing drains (`'` inline comment, `#`/` ` skip) all signal EOF immediately.

Fixed by matching the fill loop's convention: set `eof = EOF` and fall through (rather than early-`return`), so the buffer's mnemonic is still capitalized/terminated and the caller sees EOF on the same call. Applied to **both** the `FILE*` and `istream` overloads.

### 2. Regression test (`nec2cpp_tb.cpp`)
#118's validation was against the external `xnec2c-validation-data` corpus, which isn't wired into this repo's CI. Added 5 Catch2 cases (21 assertions) directly exercising `load_line`:
- over-length `CM` → next line parses as `CE` (the exact bug), for both overloads
- unterminated over-length line reports `EOF`

**Verified to have teeth**: with the drain disabled, 3 of 5 cases fail (both `CM`→`CE` cases and the EOF case).

### 3. Stale comment
`/* end of while( num_chr < max_chr ) */` → `LINE_LEN` (`max_chr` does not exist).

## Testing
- [x] Full `ctest` suite passes (2/2)
- [x] New `[load_line]` cases pass (5 cases, 21 assertions)
- [x] Sabotage test: reverting the drain makes the new tests fail (3/5) — confirms they guard the fix
- [x] No new compiler warnings

## Relationship to #118
This PR includes #118's commit as its base (cherry-picked), so the diff against `master` shows both #118's changes and these refinements together. If preferred, these can instead be requested as review suggestions on #118 directly — happy to do that instead. Otherwise, merging this supersedes #118.