### PR TITLE
fix(geometry): stop SC API cards from expanding into patch grids

### DIFF
--- a/src/c_geometry.cpp
+++ b/src/c_geometry.cpp
@@ -1971,12 +1971,18 @@ void c_geometry::sc_card(int i2,
     default:
       throw nec_exception("PATCH DATA ERROR ns ", this->patch_type );
   }
-  patch( this->patch_type, i2, 
-          this->patch_x1(0), this->patch_x1(1), this->patch_x1(2), 
+  /* The patch shape is conveyed by the ny argument (i2); nx must be 0 so
+     that patch() treats this as a single shaped patch rather than an
+     nx-by-ny grid (nx > 0 would expand each SC card into a grid of
+     patches, bloating the interaction matrix). This mirrors the
+     file-parser path (parse_sc_card), which calls
+     patch(st.card_int_1 = 0, st.card_int_2, ...). */
+  patch( 0, i2,
+          this->patch_x1(0), this->patch_x1(1), this->patch_x1(2),
           this->patch_x2(0), this->patch_x2(1), this->patch_x2(2),
           this->patch_x3(0), this->patch_x3(1), this->patch_x3(2),
           this->patch_x4(0), this->patch_x4(1), this->patch_x4(2));
-  
+
   _prev_sc = true;
 }
 
@@ -2024,16 +2030,18 @@ void c_geometry::sc_multiple_card(int i2,
     default:
       throw nec_exception("PATCH DATA ERROR i2 = ", i2 );
   }
-  
-  patch( this->patch_type, i2, 
-          this->patch_x1(0), this->patch_x1(1), this->patch_x1(2), 
+
+  /* See sc_card(): nx must be 0 to avoid patch() generating an nx-by-ny
+     grid of patches for each linked SC card in the patch string. */
+  patch( 0, i2,
+          this->patch_x1(0), this->patch_x1(1), this->patch_x1(2),
           this->patch_x2(0), this->patch_x2(1), this->patch_x2(2),
           this->patch_x3(0), this->patch_x3(1), this->patch_x3(2),
           this->patch_x4(0), this->patch_x4(1), this->patch_x4(2));
-  
+
   m_output->nec_printf( "\n"
           " %5d%c %10.5f %11.5f %11.5f %11.5f %11.5f %11.5f",
-          this->patch_type, ipt[i2], 
+          this->patch_type, ipt[i2],
           this->patch_x1(0), this->patch_x1(1), this->patch_x1(2),
           this->patch_x2(0), this->patch_x2(1), this->patch_x2(2));
 


### PR DESCRIPTION
## Problem

The python-necpp `test_multiple_sc_cards` test hung inside `nec_rp_card()` on a surface-patch model (W2IMU horn). The same model completes in ~3s through the `nec2++` CLI, so the divergence is binding-side.

## Root cause

The C-API surface-patch functions `c_geometry::sc_card()` and `sc_multiple_card()` called `patch(this->patch_type, i2, ...)`, passing the patch **shape** (e.g. `3` for quadrilateral) as `patch()`'s `nx` argument. But `patch()` treats `nx > 0` as a request to generate an **nx × ny grid** of rectangular patches — so every SC card produced a 3×3 = 9-patch grid instead of one patch.

With the model's 41× GM rotation, this bloated the geometry to **9× the intended patch count** (12852 patches vs the CLI's 1428 for the identical model), making the interaction matrix ~726× more expensive to factorize. The apparent "hang in the RP matrix solve" was actually the interaction-matrix **fill** (`cmset → compute_matrix_ss → hintg`) that `rp_card()` lazily triggers via `simulate()`.

The file-parser path (`parse_sc_card`, used by the CLI) already calls `patch(st.card_int_1 = 0, st.card_int_2, ...)` — i.e. `nx = 0` for a single shaped patch. This PR makes the API path match.

## Diagnosis notes

- Not a v2.2.0 regression — `git blame` dates the bug to 2015 (commit `0a5a4b71`); latent in v2.1.1 and earlier.
- The original report's "RP matrix solve" framing was slightly off: RP doesn't solve; it triggers `simulate()` which fills/factors the matrix.

## Verification

- A C-API harness reproducing the python-necpp call sequence (`nec_sp_card` + 34× `nec_sc_card` + GM/GW + `nec_rp_card`) hung past 30s before this change and returns in <1s after it.
- Geometry dimensions now match the CLI: matrix dim `npeq` = 2871 (was 25719 in the API path).
- CLI unchanged (gain 10.333 dB).
- No test regressions: 45/46 pass. The single failing test (`c_geometry_tb [surface_patch]`) was already failing before this change due to an unrelated, pre-existing `safe_array::segment()` off-by-one (to be addressed separately).

## Out of scope

Bug #2: `safe_array::segment(start, end)` uses an inclusive end-index but ~9 callers pass a length, truncating views by `start−1` elements and causing an OOB in `fflds` (masked in non-debug builds). Affects both CLI and API paths. To be fixed in a follow-up.
