### PR TITLE
fix(safe_array): use eigen_segment where callers mean a length

### DIFF
--- a/src/matrix_algebra.cpp
+++ b/src/matrix_algebra.cpp
@@ -330,8 +330,8 @@ void factrs(nec_output_file& s_output,    int64_t np, int64_t nrow, complex_arra
     for (int mode = 0; mode < num_symmetric_modes; mode++ ) {
         int64_t mode_offset = mode * np;
         
-        complex_array a_temp = a.segment(mode_offset, a.size()-mode_offset);
-        int_array ip_temp = ip.segment(mode_offset, ip.size()-mode_offset);
+        complex_array a_temp = a.eigen_segment(mode_offset, a.size()-mode_offset);
+        int_array ip_temp = ip.eigen_segment(mode_offset, ip.size()-mode_offset);
         
         lu_decompose(s_output,    np, a_temp, ip_temp, nrow );
     }
@@ -426,9 +426,9 @@ void solves(complex_array& a, int_array& ip, complex_array& b, int64_t neq,
 
         for (int64_t ic = 0; ic < nrh; ic++ ) {
             int64_t column_offset = ic*neq;
-            complex_array a_sub = a.segment(ia, a.size()-ia);
-            complex_array b_sub = b.segment(ia+column_offset, b.size() - (ia+column_offset) );
-            int_array ip_sub = ip.segment(ia, ip.size()-ia);
+            complex_array a_sub = a.eigen_segment(ia, a.size()-ia);
+            complex_array b_sub = b.eigen_segment(ia+column_offset, b.size() - (ia+column_offset) );
+            int_array ip_sub = ip.eigen_segment(ia, ip.size()-ia);
             solve( npeq, a_sub, ip_sub, b_sub, nrow );
         }
     } /* for( kk = 0; kk < nop; kk++ ) */

--- a/src/nec_context.cpp
+++ b/src/nec_context.cpp
@@ -2111,7 +2111,7 @@ void nec_context::cmset( int64_t nrow, complex_array& in_cm, nec_float rkhx) {
       cmww( j, i1, in2, in_cm, nrow, in_cm, nrow,1);
 
     if ( im1 <= im2) {
-      complex_array temp = in_cm.segment((ist-1)*nrow, in_cm.size() - ((ist-1)*nrow));
+      complex_array temp = in_cm.eigen_segment((ist-1)*nrow, in_cm.size() - ((ist-1)*nrow));
       cmws( j, im1, im2, temp, nrow, in_cm, nrow, 1);
       /* CMWS (J,IM1,IM2,CM(1,IST),NROW,CM,NROW,1) */
     }
@@ -2148,13 +2148,13 @@ void nec_context::cmset( int64_t nrow, complex_array& in_cm, nec_float rkhx) {
 
       if ( i1 <= in2) {
         int64_t tmp_n = (jst-1);
-        complex_array temp = in_cm.segment(tmp_n, in_cm.size()-tmp_n);
+        complex_array temp = in_cm.eigen_segment(tmp_n, in_cm.size()-tmp_n);
         cmsw( jm1, jm2, i1, in2, temp, in_cm, 0, nrow, 1);
       }
 
       if ( im1 <= im2) {
         int64_t tmp_n = (jst-1)+(ist-1)*nrow;
-        complex_array temp = in_cm.segment(tmp_n, in_cm.size()-tmp_n);
+        complex_array temp = in_cm.eigen_segment(tmp_n, in_cm.size()-tmp_n);
         compute_matrix_ss( jm1, jm2, im1, im2, temp, nrow, 1);
       }
     }
@@ -2177,7 +2177,7 @@ void nec_context::cmset( int64_t nrow, complex_array& in_cm, nec_float rkhx) {
         scm[k] = in_cm[row_offset + ka];
       }
 
-      in_cm[row_offset + j] = scm.segment(0,nop).sum(); //scm.sum(0,nop);
+      in_cm[row_offset + j] = scm.eigen_segment(0,nop).sum(); //scm.sum(0,nop);
       
       for( int k = 1; k < nop; k++ ) {
         int ka = j+ k*npeq;
@@ -6819,14 +6819,14 @@ void nec_context::ffld(nec_float thet, nec_float phi,
   /* electric field components */
   roz= rozs;
   { // without ground 
-    complex_array temp = current_vector.segment(m_geometry->n_segments, current_vector.size()-m_geometry->n_segments);
+    complex_array temp = current_vector.eigen_segment(m_geometry->n_segments, current_vector.size()-m_geometry->n_segments);
     m_geometry->fflds(rox, roy, roz, temp, &ex, &ey, &ez);
   }
   if (ground.present())  {
     // with ground
     nec_complex tempx, tempy, tempz;
     
-    complex_array temp = current_vector.segment(m_geometry->n_segments, current_vector.size()-m_geometry->n_segments);
+    complex_array temp = current_vector.eigen_segment(m_geometry->n_segments, current_vector.size()-m_geometry->n_segments);
     m_geometry->fflds(rox, roy, -roz, temp, &tempx, &tempy, &tempz);
   
     if (ground.type_perfect())  {


### PR DESCRIPTION
## Problem

`safe_array::segment(start, end)` treats its second argument as an **inclusive end index** (length = `end − start + 1`) — as asserted by the `"Segments"` unit test. Its sibling `eigen_segment(start, n)` takes a **length**.

Eleven call sites in the matrix/field path passed a *length* to `segment()`, so every such view was silently truncated by `(start − 1)` elements. Most views are large enough that the unread tail didn't matter, but `fflds()` reads right up to the end of the patch-current view and tripped a bounds violation:

```
safe_array: array index: 496 exceeds 496
```

thrown from `nec_context::ffld → c_geometry::fflds` during the surface-patch radiation-pattern computation. This is what kept the `c_geometry_tb [surface_patch]` test failing — both before and after the SC-card grid fix (#120), for this reason.

## Fix

Switch all eleven length-intent callers from `segment(start, length)` → `eigen_segment(start, length)`:

| File | Function | Sites | Path |
|---|---|---|---|
| `matrix_algebra.cpp` | `factrs()` | 2 | symmetric LU |
| `matrix_algebra.cpp` | `solves()` | 3 | symmetric solve |
| `nec_context.cpp` | `cmset()` | 4 | matrix fill + symmetry reduction |
| `nec_context.cpp` | `ffld()` | 2 | far-field patch currents |

The two `segment()` calls in `safe_array_tb.cpp` are intentionally left as-is — they exercise the end-index semantics.

This is a pure name swap: `segment` and `eigen_segment` share the identical `(int64_t, int64_t)` signature, so there are no type changes.

## Verification

- **Full suite passes with bounds asserts on** (`-DNEC_ERROR_CHECK`): 46 cases, 404 assertions — including the previously-failing `[surface_patch]`. No bounds violations anywhere.
- **`[surface_patch]` now meets its exact CLI-matching expected values**: impedance `107.95 − j7.89`, max gain `10.3332 dB`. The C-API patch path now agrees with the `nec2++` CLI.
- **No numerical regression** — bit-identical CLI output vs baseline:
  - Symmetric model `example6` (`GR 0 6`, exercises the `nop>1` paths): gain `2.236529`, Z₁ `17.792 − j117.90` — unchanged.
  - Non-symmetric `yagi`: `6.360247` / `6.246481` — unchanged.

## Context

This is **Bug #2** uncovered while investigating the surface-patch hang (Bug #1, fixed in #120). The `fflds` OOB is the direct cause of the failing `[surface_patch]` test; the symmetric-matrix sites (`factrs`/`solves`/`cmset`) had the same latent off-by-one but produced identical output because the truncated tail elements were never read in those loops.

🤖 Generated with [ZCode](https://...)
