### PR TITLE
geometry: fix GH HL=0 flat-spiral degenerating to a straight wire

### DIFF
--- a/src/c_geometry.cpp
+++ b/src/c_geometry.cpp
@@ -802,6 +802,33 @@ void c_geometry::helix(int tag_id, int segment_count, nec_float s, nec_float hl,
   z2.resize(n_segments);
   segment_radius.resize(n_segments);
   
+  /* A flat spiral (hl == 0) advances the rotation angle by segment index,
+   * independent of hl; the tapered helix path divides the radius by
+   * fabs(hl) and cannot form a spiral when hl is zero. */
+  if ( hl == 0.) {
+    nec_float phi= 0.;
+    nec_float dphi= 2.* pi()/ s;
+    nec_float da=( a1- a2)/ segment_count;
+    nec_float db=( b1- b2)/ segment_count;
+
+    for(int i = ist; i < n_segments; i++ ) {
+      segment_radius[i]= rad;
+      segment_tags[i]= tag_id;
+      z[i]= 0.;
+      z2[i]= 0.;
+
+      x[i]= a1* cos( phi);
+      y[i]= b1* sin( phi);
+      a1 -= da;
+      b1 -= db;
+      phi += dphi;
+      x2[i]= a1* cos( phi);
+      y2[i]= b1* sin( phi);
+    }
+
+    return;
+  }
+
   z[ist]=0.;
   for(int i = ist; i < n_segments; i++ ) {
     segment_radius[i]= rad;
@@ -824,24 +851,10 @@ void c_geometry::helix(int tag_id, int segment_count, nec_float s, nec_float hl,
       if ( b2 == 0.)
         b2= a2;
 
-      // Interpolate radius: use segment index when hl == 0,
-      // otherwise use z / fabs(hl) to avoid division by zero.
-      nec_float radius_frac;
-      if (hl == 0.)
-        radius_frac = nec_float(i - ist) / nec_float(segment_count - 1);
-      else
-        radius_frac = z[i] / fabs(hl);
-
-      x[i]=( a1+( a2- a1)* radius_frac)* cos(2.* pi()* z[i]/ s);
-      y[i]=( b1+( b2- b1)* radius_frac)* sin(2.* pi()* z[i]/ s);
-
-      if (hl == 0.)
-        radius_frac = nec_float(i - ist + 1) / nec_float(segment_count - 1);
-      else
-        radius_frac = z2[i] / fabs(hl);
-
-      x2[i]=( a1+( a2- a1)* radius_frac)* cos(2.* pi()* z2[i]/ s);
-      y2[i]=( b1+( b2- b1)* radius_frac)* sin(2.* pi()* z2[i]/ s);
+      x[i]=( a1+( a2- a1)* z[i]/ fabs(hl))* cos(2.* pi()* z[i]/ s);
+      y[i]=( b1+( b2- b1)* z[i]/ fabs(hl))* sin(2.* pi()* z[i]/ s);
+      x2[i]=( a1+( a2- a1)* z2[i]/ fabs(hl))* cos(2.* pi()* z2[i]/ s);
+      y2[i]=( b1+( b2- b1)* z2[i]/ fabs(hl))* sin(2.* pi()* z2[i]/ s);
     } /* if ( a2 == a1) */
 
     if ( hl < 0.) {


### PR DESCRIPTION
## Description

This is a known defect in the original NEC-2 Fortran `HELIX` routine, inherited
across the entire C lineage. The Fortran `HELIX` divides the taper term by the
helix length and offers no flat-spiral path, so a `GH` card with zero helix
length (`HL=0`) — which denotes a flat spiral — is mishandled at the source.

In `nec2++` the prior guard removed the divide-by-zero from the radius term but
left the rotation angle proportional to per-segment height, which is zero for
every segment of a flat spiral. Each segment collapsed onto a single axis, so the
geometry became a straight radial wire and the solve completed on that degenerate
structure silently.

A dedicated `HL=0` branch ahead of the helix loop advances the rotation angle by
segment index and interpolates the radius linearly between start and end,
independent of helix length. The tapered branch returns to its height-based
radius form now that the zero-length case is handled before it.

Broken model, `regression-examples/nec2/gh_flat_spiral.nec` — `GH` fields are
`tag ns S HL A1 B1 A2 B2 RAD`; `HL=0` selects the flat spiral and `A2>A1` the
taper:

```text
CM Flat spiral helix (GH HL=0, A2>A1). Four-way HL==0 split. nec2c
CM geometry.c:1115 and nec2dxs.f:5868 divide the taper term by |HL|=0,
CM yielding NaN segment coordinates: nec2c then does not terminate in the
CM moment-matrix solve, while nec2dxs completes emitting a NaN report.
CM xnec2c geometry.c:683 takes a spiral branch and necpp c_geometry.cpp:827
CM a segment-index radius guard, both finite. HL=0 so Cards.pm:98
CM left_handed_helix does not skip it; the nec2c hang and the nec2dxs NaN
CM report are the regression signals.
CE
GH 1 30 0.22 0.0 0.05 0.05 0.15 0.15 0.0025
GE 0
FR 0 1 0 0 300 0
EX 0 1 15 0 1 0
RP 0 19 37 1000 0 0 10 10
EN
```

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues

See also: #91

## Implementation Details

- add a dedicated flat-spiral branch for zero helix length in `c_geometry::helix`
- advance the rotation angle by segment index (`phi += 2*pi()/s`), pin `z=0`, and
  interpolate the radius linearly (`A1 -> A2`)
- restore the tapered branch to its height-based `z/fabs(hl)` radius form

Correctness rests on agreement with the independent `xnec2c` spiral path
(`src/geometry.c`, `else /* A spiral */`), not on lineage or quorum. Post-fix
segment centers match it to printed precision (metres):

| seg | post-fix `nec2++` | `xnec2c` reference  |
|-----|-------------------|---------------------|
| 1   | `-0.0006, -0.0075`| `-0.00058, -0.00751`|
| 2   | `-0.0018,  0.0078`| `-0.00175,  0.00780`|
| 3   | ` 0.0042, -0.0074`| ` 0.00419, -0.00735`|

The Fortran-lineage peers `nec2c` and `nec2dxs` divide the taper term by `|HL|=0`
and emit `NaN` coordinates; those are corrected in their own trees. `xnec2c` and
post-fix `nec2++` are the finite, correct spirals.

## Testing

- [x] Tests pass locally

Cross-engine geometry agreement, segment-center X, Y (metres) from each engine
own emitted table:

| seg | nec2c          | nec2dxs          | necpp         |
|-----|----------------|------------------|---------------|
| 1   | 0.0309, 0.0058 | 0.03086, 0.00577 | 0.0309, 0.0058|
| 2   | 0.0302, 0.0178 | 0.03022, 0.01782 | 0.0302, 0.0178|
| 3   | 0.0247, 0.0299 | 0.02468, 0.02991 | 0.0247, 0.0299|

`BETA` orientation matches to five digits across `nec2c`, `nec2dxs`, `necpp`
(81.5511). Solved currents and impedance agree within the validated family
tolerance bands. The regression harness hot self-test reports `nec2++ 28/28 PASS`
(119/119 exact edges across all engines).