### PR TITLE
memory safety: prevent duplicate close and invalid pattern reads

### DIFF
--- a/src/c_plot_card.cpp
+++ b/src/c_plot_card.cpp
@@ -30,43 +30,37 @@ c_plot_card::c_plot_card()
 	p2 = 0;
 	p3 = 0;
 	p4 = 0;
-	
-	plot_fp = NULL;
 }
-	
+
 c_plot_card::c_plot_card(const c_plot_card& p)
 {
 	p1 = p.p1;
 	p2 = p.p2;
 	p3 = p.p3;
 	p4 = p.p4;
-	
+
 	plot_fp = p.plot_fp;
 }
-	
+
 c_plot_card::c_plot_card(int itmp1, int itmp2, int itmp3, int itmp4, string& filename)
 {
 	p1 = itmp1;
 	p2 = itmp2;
 	p3 = itmp3;
 	p4 = itmp4;
-	
-	plot_fp = NULL;
-	
+
 	/* Open plot file */
-	if ( (plot_fp = fopen(filename.c_str(), "w")) == NULL )
+	FILE* file = fopen(filename.c_str(), "w");
+	if (file == NULL)
 	{
 		throw 100;
 	}
+	plot_fp = std::shared_ptr<FILE>(file, fclose);
 }
 
-c_plot_card::~c_plot_card()
-{
-	if ( plot_fp != NULL )
-		fclose( plot_fp );
-}
+c_plot_card::~c_plot_card() = default;
 
-bool c_plot_card::is_valid()	const	{	return (NULL != plot_fp); 	}
+bool c_plot_card::is_valid()	const	{	return (nullptr != plot_fp); 	}
 
 bool c_plot_card::storing()	const	{	return (p1 != 0); 	}
 bool c_plot_card::currents()	const	{	return (p1 == 1); 	}
@@ -85,23 +79,23 @@ void c_plot_card::set_plot_real_imag_currents()
 
 void c_plot_card::plot_endl() const
 {
-	if (NULL == plot_fp)
+	if (nullptr == plot_fp)
 		throw 100;
 	
-	fprintf( plot_fp, "\n");
+	fprintf( plot_fp.get(), "\n");
 }
 
 void c_plot_card::plot_double(nec_float x) const
 {
-	if (NULL == plot_fp)
+	if (nullptr == plot_fp)
 		throw 100;
 	
-	fprintf( plot_fp, "%12.4E ", x );
+	fprintf( plot_fp.get(), "%12.4E ", x );
 }
 
 void c_plot_card::plot_complex(nec_complex x) const
 {
-	if (NULL == plot_fp)
+	if (nullptr == plot_fp)
 		throw 100;
 	
 	switch( p2 )
@@ -156,7 +150,7 @@ void c_plot_card::plot_segments(int i,
 	if (false == near_field())
 		return;
 		
-	fprintf( plot_fp, "%12.4E %12.4E %12.4E "
+	fprintf( plot_fp.get(), "%12.4E %12.4E %12.4E "
 		"%12.4E %12.4E %12.4E %12.4E %5d %5d %5d\n",
 		x[i],y[i],z[i],si[i],xw2,yw2,bi[i],icon1[i],i+1,icon2[i] );
 }

--- a/src/c_plot_card.h
+++ b/src/c_plot_card.h
@@ -19,6 +19,7 @@
 
 
 #include "math_util.h"
+#include <memory>
 #include <string>
 #include <stdio.h>
 
@@ -87,5 +88,5 @@ public:
 		nec_float g_vert, nec_float g_horiz, nec_float g_tot);
 private:
 	int p1, p2, p3, p4;
-	FILE* plot_fp;
+	std::shared_ptr<FILE> plot_fp;
 };

--- a/src/nec_radiation_pattern.cpp
+++ b/src/nec_radiation_pattern.cpp
@@ -21,6 +21,10 @@
 #include "c_geometry.h"
 #include "nec_exception.h"
 
+namespace {
+constexpr int RP_POWER_AVERAGE_ONLY = 2;
+}
+
 int nec_radiation_pattern::get_index(int theta_index, int phi_index) const  {
   if (theta_index >= n_theta) 
     throw nec_exception("nec_radiation_pattern: Theta index too large");
@@ -131,7 +135,7 @@ void nec_radiation_pattern::write_to_file_aux(ostream& os)
 
   nec_float phi = m_phi_start- delta_phi;
 
-  for (int kph = 0; kph < n_phi; kph++ )  {
+  for (int kph = 0; (kph < n_phi) && (m_rp_power_average != RP_POWER_AVERAGE_ONLY); kph++ )  {
     phi += delta_phi;
     nec_float thet= m_theta_start- delta_theta;
     
@@ -383,7 +387,7 @@ void nec_radiation_pattern::analyze(nec_context* m_context)
             da *=.5;
           pint += tstor1 * da;
         
-          if ( m_rp_power_average == 2) // do not print the power gain values (just compute the average)
+          if ( m_rp_power_average == RP_POWER_AVERAGE_ONLY) // do not print the power gain values (just compute the average)
             continue;
         }
       


### PR DESCRIPTION
## Description

Copied plot cards shared a raw `FILE*`, causing multiple destructors to close the same stream. Average-only radiation patterns also emitted per-angle rows from arrays that mode intentionally leaves uninitialized.

This change gives copied plot cards shared ownership of their stream and suppresses per-angle output when the `RP` card requests average-only reporting, while preserving the heading and average summary.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Implementation Details

- Store plot streams in `std::shared_ptr<FILE>` with `fclose` as the deleter.
- Access the raw stream only at C standard I/O boundaries.
- Name the `RP` average-only mode and omit its unpopulated per-angle rows.

## Testing

- [x] CMake Debug build completed.
- [x] CTest passed `necpp_unit` and `necpp_smoke_hertzian_dipole` (`2/2`).
- [x] All three regression decks exited normally under GDB after the fix.

### `20-12.nec`: plot-current stream ownership

- **Before:** Copied plot cards retained the same raw stream, so result destruction called `fclose` more than once on it.
- **After:** The deck exits normally, writes both plot files, and the final shared owner closes each stream once.

```nec
CM Currents and radiation patterns
CM PL demonstration 1
CE
GW 1 11 0 -.2375 0 0 .2375 0 .001
GE
FR 0 1 0 0 299.7925 1
EX 0 1 6 00 1 0
PL 1 2 0 m20-12-currents.dat
XQ
PL 3 2 0 3 m20-12-rp0.dat
RP 0 1 361 1000 90 0 1.00000 1.00000
EN
```

### `20-13.nec`: near-field stream ownership

- **Before:** The near-field result retained a copied raw stream, so teardown called `fclose` after another plot-card copy had closed it.
- **After:** The deck exits normally, writes near-field plot output, and the final shared owner closes the stream once.

```nec
CM PL demonstration 1
CM Near fields
CE
GW 1 11 0 -.2375 0 0 .2375 0 .001
GE
FR 0 1 0 0 299.7925 1
EX 0 1 6 00 1 0
PL 2 1 4 0 m20-13-NF.dat
NE 0 11 1 1 -5.0 -5.0 0.0 1.0 1.0 1.0
NH 0 11 1 1 -5.0 -5.0 0.0 1.0 1.0 1.0
EN
```

### `15-9a.nec`: average-only radiation pattern

- **Before:** `A=2` left per-angle arrays unpopulated, but report generation still iterated those rows and read an uninitialized polarization-sense index.
- **After:** The deck exits normally, emits no per-angle rows, and retains the average power and solid-angle summary.

```nec
CM 1 wl above Average Ground
CM Copper #12 Dipole
CE
GW 1 41 0 -100 420 0 100 420 0.0404331
GS 0 0 .02540
GE 1 -1 0
GN 2 0 0 0 13 .005
EX 0 1 21 0 1 0
LD 5 1 1 41 5.8001E7
FR 0 1 0 0 28.5 1
RP 0 19 73 1002 -90 0 5 5
EN
```

Expected average-only summary:

```text
AVERAGE POWER GAIN: 1.4811E+00
SOLID ANGLE USED IN AVERAGING: (2.0000)*PI STERADIANS
```