### PR TITLE
symmetry: fix gx solve and three-plane reflection

### DIFF
--- a/src/c_geometry.cpp
+++ b/src/c_geometry.cpp
@@ -1152,29 +1152,28 @@ void c_geometry::reflect_plane( int sym_plane, int& tag_increment )
 
   /* --- planar symmetry --- */
   /* sym_plane bits: 0 = negate X, 1 = negate Y, 2 = negate Z */
-  int mask = sym_plane;
-  bool neg_x = mask & 1;
-  bool neg_y = mask & 2;
-  bool neg_z = mask & 4;
-  int num_axes = (neg_x?1:0) + (neg_y?1:0) + (neg_z?1:0);
-  int num_copies = 1 << num_axes;   /* 2 for single axis, 4 for two axes */
-
   int64_t orig_n = n_segments;
   int64_t orig_m = m;
   int itx = tag_increment;
 
-  /* Axis priority: Z (bit 2) > Y (bit 1) > X (bit 0).
-     For two-axis combos, copy order is: original, axis1-neg, axis2-neg, both-neg.
-     Tag increments: +0, +itx, +2*itx, +3*itx. */
-  int axis1_mask = 0, axis2_mask = 0;
-  if ( neg_z ) { axis1_mask = 4; axis2_mask = neg_y ? 2 : (neg_x ? 1 : 0); }
-  else if ( neg_y ) { axis1_mask = 2; axis2_mask = neg_x ? 1 : 0; }
-  else if ( neg_x ) { axis1_mask = 1; }
+  /* Build copy masks in the Z, Y, X order used by sequential NEC-2
+     reflection passes. Each pass appends a reflected copy of every existing
+     combination. */
+  int copy_mask[8] = { 0 };
+  int num_copies = 1;
 
-  int tag_inc[4] = { 0, itx, 2*itx, 3*itx };
+  for ( int axis_mask = 4; axis_mask > 0; axis_mask >>= 1 )
+  {
+    if ( 0 == (sym_plane & axis_mask) )
+      continue;
 
-  /* Final tag_increment: X never doubles, Z and Y always double */
-  tag_increment = itx << ( (neg_z ? 1 : 0) + (neg_y ? 1 : 0) );
+    for ( int copy = 0; copy < num_copies; copy++ )
+      copy_mask[num_copies + copy] = copy_mask[copy] | axis_mask;
+
+    num_copies *= 2;
+  }
+
+  tag_increment = itx * num_copies;
 
   /* --- SEGMENTS --- */
   if ( orig_n > 0 )
@@ -1196,23 +1195,9 @@ void c_geometry::reflect_plane( int sym_plane, int& tag_increment )
     for( int copy = 1; copy < num_copies; copy++ )
     {
       /* Determine which axes to negate for this copy */
-      bool flip_x = false, flip_y = false, flip_z = false;
-      if ( copy == 1 )
-      {
-	if ( axis1_mask == 4 ) flip_z = true;
-	else if ( axis1_mask == 2 ) flip_y = true;
-	else if ( axis1_mask == 1 ) flip_x = true;
-      }
-      else if ( copy == 2 )
-      {
-	if ( axis2_mask == 4 ) flip_z = true;
-	else if ( axis2_mask == 2 ) flip_y = true;
-	else if ( axis2_mask == 1 ) flip_x = true;
-      }
-      else if ( copy == 3 )
-      {
-	flip_x = neg_x; flip_y = neg_y; flip_z = neg_z;
-      }
+      bool flip_x = (0 != (copy_mask[copy] & 1));
+      bool flip_y = (0 != (copy_mask[copy] & 2));
+      bool flip_z = (0 != (copy_mask[copy] & 4));
 
       int64_t base = copy * orig_n;
 
@@ -1269,7 +1254,7 @@ void c_geometry::reflect_plane( int sym_plane, int& tag_increment )
 	if ( itagi == 0 )
 	  segment_tags[nx] = 0;
 	if ( itagi != 0 )
-	  segment_tags[nx] = itagi + tag_inc[copy];
+	  segment_tags[nx] = itagi + copy * itx;
 
 	segment_radius[nx] = segment_radius[i];
       }
@@ -1298,23 +1283,9 @@ void c_geometry::reflect_plane( int sym_plane, int& tag_increment )
 
     for( int copy = 1; copy < num_copies; copy++ )
     {
-      bool flip_x = false, flip_y = false, flip_z = false;
-      if ( copy == 1 )
-      {
-	if ( axis1_mask == 4 ) flip_z = true;
-	else if ( axis1_mask == 2 ) flip_y = true;
-	else if ( axis1_mask == 1 ) flip_x = true;
-      }
-      else if ( copy == 2 )
-      {
-	if ( axis2_mask == 4 ) flip_z = true;
-	else if ( axis2_mask == 2 ) flip_y = true;
-	else if ( axis2_mask == 1 ) flip_x = true;
-      }
-      else if ( copy == 3 )
-      {
-	flip_x = neg_x; flip_y = neg_y; flip_z = neg_z;
-      }
+      bool flip_x = (0 != (copy_mask[copy] & 1));
+      bool flip_y = (0 != (copy_mask[copy] & 2));
+      bool flip_z = (0 != (copy_mask[copy] & 4));
 
       int neg_count = (flip_x?1:0) + (flip_y?1:0) + (flip_z?1:0);
       bool neg_psalp = (neg_count % 2 == 1);

--- a/src/matrix_algebra.cpp
+++ b/src/matrix_algebra.cpp
@@ -398,7 +398,11 @@ void solves(complex_array& a, int_array& ip, complex_array& b, int64_t neq,
 
             /* transform matrix eq. rhs vector according to symmetry modes */
             for (int64_t i = 0; i < npeq; i++ ) {
-                nec_complex sum_normal(b[i+column_offset]);
+                /* Each image row below is seeded from this row's untransformed
+                   value, so hold it in scm[0] before the normalized sum
+                   overwrites b[i]. */
+                scm[0] = b[i+column_offset];
+                nec_complex sum_normal(scm[0]);
                 for (int64_t k = 1; k < nop; k++ ) {
                     int64_t ia= i+ k* npeq;
                     scm[k]= b[ia+column_offset];
@@ -441,7 +445,11 @@ void solves(complex_array& a, int_array& ip, complex_array& b, int64_t neq,
     for (int64_t ic = 0; ic < nrh; ic++ ) {
         int64_t column_offset = ic*neq;
         for (int64_t i = 0; i < npeq; i++ ) {
-            nec_complex sum_normal(b[i+column_offset]);
+            /* Each image row below is seeded from this row's untransformed
+               value, so hold it in scm[0] before the summed value overwrites
+               b[i]. */
+            scm[0] = b[i+column_offset];
+            nec_complex sum_normal(scm[0]);
             for (int64_t k = 1; k < nop; k++ ) {
                 int64_t ia= i+ k* npeq;
                 scm[k]= b[ia+column_offset];

--- a/src/nec_context.cpp
+++ b/src/nec_context.cpp
@@ -6439,14 +6439,17 @@ void nec_context::fblock( int nrow, int ncol, int64_t imax, int ipsym ) {
   int kk=1;
   symmetry_array[0]=cplx_10();
   
-  if ((2 == nop) || (4 == nop) || (8 == nop))
-      return;
-  int ka = nop / 2;
-  
-//   int k_power = 2;
-//   for( ka = 1; k_power != nop; ka++ )
-//     k_power *= 2;
-  
+  /* Plane symmetry admits two, four, or eight sections; the doubling below
+     cannot span the matrix for any other count. */
+  if ((2 != nop) && (4 != nop) && (8 != nop))
+      nec_stop("SYMMETRY ERROR - NOP: %d", nop );
+
+  /* Each pass doubles the width of the filled block, so the pass count is
+     log2(nop). */
+  int ka = 1;
+  for (int k_power = 2; k_power != nop; k_power *= 2)
+    ka++;
+
   for(int k = 0; k < ka; k++ )  {
     for(int i = 0; i < kk; i++ )  {
       for(int j = 0; j < kk; j++ )  {


### PR DESCRIPTION
## Description

Any structure with a `GX` card solved incorrectly. Most decks returned `INF` feed impedance and a dead radiation pattern; some returned a plausible but wrong impedance. Two of the three causes are uninitialized reads, so the wrong numbers were not even stable: running the same binary twice on the same deck printed different currents.

Three separate defects, one in each stage of the symmetry path. NEC reflects the structure across the symmetry planes, solves a reduced matrix over one section, then expands that solution onto the image sections. Each stage had its own defect, and the first two must be fixed together to get a finite answer.

- `src/matrix_algebra.cpp` - the mode transform in `solves()` read a scratch slot that nothing ever wrote. Masked on structures with both wires and patches by an earlier bulk fill, so it bit wire-only decks.
- `src/nec_context.cpp` - the guard in `fblock()` had its sense inverted, so legal section counts of 2, 4, and 8 returned early and left the modal coefficient table populated at one element. The pass count was also `nop / 2` where the block doubles per pass, so it must be `log2(nop)`; the two agree at 2 and 4 and diverge at 8.
- `src/c_geometry.cpp` - three symmetry planes need eight copies, but the copy loop only handled three of them and the tag table held four entries. Copies 4 through 7 were written unreflected, and the X plane was left out of the tag increment.

Found by differential comparison against `nec2c`, `nec2dx`, `nec2dxs`, and `xnec2c` over 1219 decks. The unit tests pass with all three defects present and with all three corrected: `matrix_algebra_tb.cpp:214` calls `solves()` with `nop = 1`, which touches none of these lines, and no unit test builds geometry from a `GX` card.

The four reproduction decks are embedded in full below, since they are not in this repository. Each is preceded by its exact expected result.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Testing

- [x] Tests pass locally
- [x] New tests added for new functionality

```text
ctest --test-dir build-tests
1/2 Test #1: necpp_unit .......................   Passed
2/2 Test #2: necpp_smoke_hertzian_dipole ......   Passed
100% tests passed, 0 tests failed out of 2
```

Built and run with GCC 11.5.0:

```sh
cmake -S . -B build-tests -DCMAKE_BUILD_TYPE=None -DNECPP_BUILD_TESTS=ON \
      -DCMAKE_CXX_FLAGS="-std=c++17 -O0 -ffp-contract=off"
cmake --build build-tests
build-tests/src/nec2++ -i deck.nec -o deck.txt
```

### Deck 1 of 4, one symmetry plane

Four vertical dipoles, two of them made by the card. Wire-only, which is what exposes the scratch-slot defect. Run this one twice and diff the two outputs to see the instability.

- Before: all four feeds report `IMPEDANCE` of `INF`. Segments 23 through 44 print currents near `2.79E-311`, and those digits change between consecutive runs of the same binary. Total gain is down by 1.0, the image sections radiate nothing.
- After: tags 1 and 3 report `6.5696E+01 -7.5480E-01`, tags 2 and 4 report `5.2830E+01 -9.7183E+00`, stable across runs. Agrees with all four reference engines to `2.0e-3` on resistance and `1.35e-2` on reactance.

```nec
CM 4 Vertical Dipoles, spaced 1/2 wl, fed in phase
CM EX referred to Tag # and Rel. Seg. #
CM 2 GW, other 2 by GX
CM https://antenna2.github.io/cebik/books/Basic-Intermediate-Tutorial-Models.zip { /Tutorial-2/ch-5/5-1b.nec }
CE
GW 1 11 -.75 0 -.245 -.75 0 .245 .001   
GW 2 11 -.25 0 -.245 -.25 0 .245 .001   
GX 2 100          
GE 0           
EX 0 1 6 00 1 0     
EX 0 2 6 00 1 0     
EX 0 4 6 00 1 0     
EX 0 3 6 00 1 0    
FR 0 1 0 0 299.7925 1     
RP 0 1 361 1000 90 0 1.00000 1.00000   
EN
```

Fixing the scratch slot alone is not enough here: impedance moves from infinite to finite and still wrong, roughly 22 ohms off, because the transform then reads a sound seed and multiplies it by an uninitialized coefficient table. Both solver fixes are needed together.

### Deck 2 of 4, two symmetry planes

- Before: all four fed tags report `IMPEDANCE` of `INF`.
- After: all four fed tags report `5.0965E+01 7.2878E+00`.

```nec
CM 6-el 2M Yagi:  GX 4 square: Revised EX lines
CM https://antenna2.github.io/cebik/books/Antenna-Modeling-Notes-Models-Vol-1-4.zip { /Vol-3/nec/72-5.nec }
CE
GW 1,21,-.514604,0.,0.,.514604,0.,0.,.0023813
GW 2,21,-.5075174,.257302,0.,.5075174,.257302,0.,.0023813
GW 3,21,-.4746752,.3637788,0.,.4746752,.3637788,0.,.0023813
GW 4,21,-.461137,.6585204,0.,.461137,.6585204,0.,.0023813
GW 5,21,-.461137,.9469628,0.,.461137,.9469628,0.,.0023813
GW 6,21,-.443992,1.377137,0.,.443992,1.377137,0.,.0023813
GM 0 0 0 0 0 -1.026668 0 -1.026668 
GX 6 101 
GE 0
LD 5,0,0,0,2.5E+07,1.
FR 0,1,0,0,146.
GN -1
EX 0,2,11,0,1.414214,0.
EX 0,8,11,0,1.414214,0.
EX 0,14,11,0,-1.414214,0.
EX 0,20,11,0,-1.414214,0.
RP 0,1,361,1000,90.,0.,0.,1.,0.
EN
```

### Deck 3 of 4, three symmetry planes

Nothing in the survey corpus reaches eight sections in a solvable state, so this deck was written for it: one wire under `GX 1 111`, 72 segments over a nine-segment cell. Eight sections is the only count that separates the correct pass count from `nop / 2`, and it is the only count that reaches the reflection defect. The wire sits in the +x+y+z octant clear of all three planes, and feeding one section of eight keeps every symmetry mode excited; a symmetric feed would exercise one mode and leave the other seven unmeasured.

- Before: `1.8595E+01 -6.6708E+02`. Repeatable, not an uninitialized read, this stage builds the wrong antenna and then solves it correctly. The structure comes out as four distinct wires plus four coincident copies of wire 1, tagged `1,2,3,4,1,1,1,1`, which the junction search then wires into a chain that does not exist.
- After: `1.3682E+01 -4.7048E+02`, matching deck 4 below and all four reference engines.

```nec
CM Plane symmetry across three reflection planes: GX 111 yields NOP=8, the
CM one admissible plane-symmetry count no other deck in the corpus reaches.
CM NOP=8 alone discriminates the fblock pass count: the doubling derivation
CM gives KA=3, a KA=NOP/2 derivation gives 4 and walks the coefficient block
CM past its last row. At NOP=2 and NOP=4 the two derivations agree.
CM Segment length is 0.028 wavelength against a 0.001 wavelength radius, so
CM the thin-wire kernel holds and the matrix stays well conditioned: the
CM regression signal is the symmetry path, not amplified rounding.
CE
GW 1 9 0.1 0.1 0.1 0.1 0.1 0.35 0.001
GX 1 111
GE 0
EX 0 1 5 0 1 0
FR 0 1 0 0 299.8 0
RP 0 19 37 1000 0 0 10 10
EN
```

### Deck 4 of 4, the control for deck 3

The same eight wires that `GX 111` generates, written as explicit `GW` cards, so the symmetry path is never entered. The symmetry decomposition is an exact change of basis, so an engine must return the same feed impedance for deck 3 as it returns here. That makes each engine its own reference; no engine is judged against another.

- Before: `1.3682E+01 -4.7048E+02`. Unaffected by any of the three defects, which is the point of the control.
- After: `1.3682E+01 -4.7048E+02`, unchanged, now matched by deck 3.

```nec
CM Symmetry-free control for gx_plane_sym_nop8.nec. The same eight wires the
CM GX 111 card generates, written out as explicit GW cards, so ipsym stays 0
CM and NOP=1 leaves the plane-symmetry path unentered.
CM Wire 1 and its feed match the NOP=8 deck exactly; wires 2 through 8 carry
CM the reflections in x, y, and z that GX 111 appends.
CE
GW 1 9 0.1 0.1 0.1 0.1 0.1 0.35 0.001
GW 2 9 -0.1 0.1 0.1 -0.1 0.1 0.35 0.001
GW 3 9 0.1 -0.1 0.1 0.1 -0.1 0.35 0.001
GW 4 9 -0.1 -0.1 0.1 -0.1 -0.1 0.35 0.001
GW 5 9 0.1 0.1 -0.1 0.1 0.1 -0.35 0.001
GW 6 9 -0.1 0.1 -0.1 -0.1 0.1 -0.35 0.001
GW 7 9 0.1 -0.1 -0.1 0.1 -0.1 -0.35 0.001
GW 8 9 -0.1 -0.1 -0.1 -0.1 -0.1 -0.35 0.001
GE 0
EX 0 1 5 0 1 0
FR 0 1 0 0 299.8 0
RP 0 19 37 1000 0 0 10 10
EN
```

Deck 3 against deck 4, each engine judged against its own control:

| engine | three planes | control | agrees with itself |
|---|---|---|---|
| `nec2c` | 13.681 - j470.49 | 13.681 - j470.49 | yes |
| `nec2dx`, `nec2dxs` | 1.36813E+01 - j4.70488E+02 | identical | yes |
| `xnec2c` | 13.6813311354218 - j470.48839988314484 | agrees to 1e-13 | yes |
| `nec2++` before | 18.595 - j667.08 | 13.682 - j470.48 | no |
| `nec2++` after | 13.682 - j470.48 | 13.682 - j470.48 | yes |

### Corpus result

Across 1219 decks and 46457028 compared points, no engine pair against a freshly solved `nec2++` reports `INF` on any deck. Both the before and after runs solve 1193 of 1219, so the fixes introduce no new solve failures; the 26 are pre-existing card parser and runtime failures unrelated to symmetry.