### PR TITLE
geometry: accept tab as a numeric field separator

### DIFF
--- a/src/c_geometry.cpp
+++ b/src/c_geometry.cpp
@@ -25,7 +25,19 @@
 #include <cctype>
 #include <stdint.h>
 
-c_geometry::c_geometry() 
+/**
+ * geometry_field_separator - Determine whether a character separates fields
+ * @character: Character read from a geometry card
+ *
+ * Return: true for NEC commas, whitespace, and the line terminator.
+ */
+static bool geometry_field_separator(char character)
+{
+  return (std::isspace(static_cast<unsigned char>(character)) != 0) ||
+    (character == ',') || (character == '\0');
+}
+
+c_geometry::c_geometry()
     : patch_x1(0,0,0), patch_x2(0,0,0), patch_x3(0,0,0), patch_x4(0,0,0)  {
   n_segments = 0;
   np = 0;   // n_segments is the number of segments
@@ -2383,7 +2395,7 @@ void c_geometry::parse_geometry_card_line(const char* line_buf, char *gm,
     integer_params[i] = atoi( &line_buf[line_idx] );
 
     line_idx--;
-    while( (line_buf[++line_idx] != ' ') && (line_buf[line_idx] != ',') && (line_buf[line_idx] != '\0') )
+    while( !geometry_field_separator(line_buf[++line_idx]) )
     {
       if ( ((line_buf[line_idx] < '0') || (line_buf[line_idx] > '9')) &&
           (line_buf[line_idx] != '+') && (line_buf[line_idx] != '-') )
@@ -2419,7 +2431,7 @@ void c_geometry::parse_geometry_card_line(const char* line_buf, char *gm,
     real_params[i] = atof( &line_buf[line_idx] );
 
     line_idx--;
-    while( (line_buf[++line_idx] != ' ') && (line_buf[line_idx] != ',') && (line_buf[line_idx] != '\0') )
+    while( !geometry_field_separator(line_buf[++line_idx]) )
     {
       if ( ((line_buf[line_idx] < '0') || (line_buf[line_idx] > '9')) &&
         (line_buf[line_idx] != '.') && (line_buf[line_idx] != '+') &&

--- a/src/nec2cpp_tb.cpp
+++ b/src/nec2cpp_tb.cpp
@@ -9,6 +9,7 @@
 
 #include <cstdio>
 #include <cstring>
+#include <memory>
 #include <string>
 #include <sstream>
 
@@ -334,6 +335,26 @@ TEST_CASE("load_line(istream) drains over-length CM, next line parses as CE",
     REQUIRE(load_line(buf, is) == 0);
     REQUIRE(buf[0] == 'C');
     REQUIRE(buf[1] == 'E');
+}
+
+TEST_CASE("geometry parser accepts tab-separated fields", "[geometry][parser]") {
+    // Build one valid wire deck with tabs delimiting every geometry field.
+    const char deck[] =
+        "GW\t1\t3\t0\t0\t0\t0\t0\t1\t0.001\n"
+        "GE\t0\n";
+    std::unique_ptr<FILE, decltype(&std::fclose)> input(
+        std::tmpfile(), &std::fclose);
+    REQUIRE(input != nullptr);
+    REQUIRE(std::fwrite(deck, 1, sizeof(deck) - 1, input.get()) ==
+        sizeof(deck) - 1);
+    std::rewind(input.get());
+
+    // Parse through the public file interface and retain the generated segments.
+    nec_context nec;
+    nec.initialize();
+    c_geometry* geometry = nec.get_geometry();
+    REQUIRE_NOTHROW(geometry->parse_geometry(&nec, input.get()));
+    REQUIRE(geometry->n_segments == 3);
 }
 
 TEST_CASE("load_line returns EOF when an over-length line is the last line",


### PR DESCRIPTION
## Description

Decks that separate geometry-card fields with tabs failed to load. Any card whose
numeric fields are tab-delimited aborted parsing at the first tab, so otherwise
valid models could not be solved. Spaces and commas already worked; tab was
simply absent from the terminator set used to close a numeric field.

The integer and real field scanners each carried their own inline terminator
test, so the two could disagree. This change gives both one shared separator
rule and adds a permanent regression test through the public file parser.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Implementation Details

- `src/c_geometry.cpp`: adds the file-local query `geometry_field_separator()`,
  which classifies `std::isspace()` whitespace, the NEC comma, and the NUL
  terminating the loaded card. The character is converted to `unsigned char`
  before classification so negative plain-`char` values never reach the C
  character-classification interface. Both post-conversion scans in
  `parse_geometry_card_line()` call it, so the integer and real paths cannot
  drift apart. Numeric syntax checking stays in the existing scanner loops.
- `src/nec2cpp_tb.cpp`: adds the regression described below.

## Reproduction

`<TAB>` denotes one horizontal-tab byte, `0x09`. Original failing deck line from
`86-2-ex9.nec`:

```text
SP 0<TAB>0 .13795 .13795<TAB>.98079<TAB>78.75<TAB>45.<TAB>.11957
```

Before: parsing aborts at character 5, the tab immediately following the first
integer field:

```text
GEOMETRY DATA CARD "SP" ERROR: NON-NUMERICAL CHARACTER '<TAB>' IN INTEGER FIELD AT CHAR. 5
```

After: the deck reaches its end card and reports `TOTAL RUN TIME:`.

## Testing

The permanent regression writes this complete input to a temporary file, parses
it with `c_geometry::parse_geometry(nec_context *, FILE *)`, and asserts the
segment count. It exercises tab termination in both the integer and the real
scanner.

```text
GW<TAB>1<TAB>3<TAB>0<TAB>0<TAB>0<TAB>0<TAB>0<TAB>1<TAB>0.001
GE<TAB>0
```

Before: parsing aborts at the first tab after an integer field.
After: parsing completes with `n_segments == 3`.

```sh
cmake --build build --target nec2++ nec2++_tests
ctest --test-dir build --output-on-failure
```

Result:

```text
All tests passed (568 assertions in 52 test cases)
```

- [x] Tests pass locally
- [x] New tests added for new functionality
